### PR TITLE
Port accounts and authentication to the monorepo

### DIFF
--- a/apps/api/prisma/migrations/20260325000000_add_auth/migration.sql
+++ b/apps/api/prisma/migrations/20260325000000_add_auth/migration.sql
@@ -1,0 +1,28 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_User" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "passwordHash" TEXT NOT NULL DEFAULT '',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+INSERT INTO "new_User" ("email", "id", "name", "passwordHash", "createdAt", "updatedAt")
+SELECT "email", "id", "name", '', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP FROM "User";
+DROP TABLE "User";
+ALTER TABLE "new_User" RENAME TO "User";
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+
+CREATE TABLE "Session" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "tokenHash" TEXT NOT NULL,
+    "expiresAt" DATETIME NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "userId" INTEGER NOT NULL,
+    CONSTRAINT "Session_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE UNIQUE INDEX "Session_tokenHash_key" ON "Session"("tokenHash");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -11,16 +11,29 @@ datasource db {
 }
 
 model User {
-  id        Int @id @default(autoincrement())
-  name      String
-  email     String @unique
-  wishlists Wishlist[]
+  id           Int       @id @default(autoincrement())
+  name         String
+  email        String    @unique
+  passwordHash String
+  sessions     Session[]
+  wishlists    Wishlist[]
+  createdAt    DateTime  @default(now())
+  updatedAt    DateTime  @updatedAt
+}
+
+model Session {
+  id        Int      @id @default(autoincrement())
+  tokenHash String   @unique
+  expiresAt DateTime
+  createdAt DateTime @default(now())
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId    Int
 }
 
 model Wishlist {
-  id        Int     @id @default(autoincrement())
+  id        Int            @id @default(autoincrement())
   title     String
-  user      User    @relation(fields: [userId], references: [id])
+  user      User           @relation(fields: [userId], references: [id])
   userId    Int
   items     WishlistItem[]
 }

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -1,13 +1,21 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { PrismaClient } from '@prisma/client';
+import { randomBytes, scryptSync } from 'node:crypto';
 
 const prisma = new PrismaClient();
+
+function hashPassword(password: string) {
+  const salt = randomBytes(16).toString('hex');
+  const hash = scryptSync(password, salt, 64).toString('hex');
+  return `${salt}:${hash}`;
+}
 
 async function main() {
   const user1 = await prisma.user.create({
     data: {
       name: 'Alice',
       email: 'alice@example.com',
+      passwordHash: hashPassword('password123'),
       wishlists: {
         create: {
           title: 'Birthday Wishlist',
@@ -27,6 +35,7 @@ async function main() {
     data: {
       name: 'Bob',
       email: 'bob@example.com',
+      passwordHash: hashPassword('password123'),
       wishlists: {
         create: {
           title: 'Holiday Wishlist',

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { AuthModule } from './auth/auth.module';
 import { PrismaModule } from './prisma/prisma.module';
 import { WishlistItemsModule } from './wishlist-items/wishlist-items.module';
 import { WishlistsModule } from './wishlists/wishlists.module';
 
 @Module({
-  imports: [PrismaModule, WishlistItemsModule, WishlistsModule],
+  imports: [PrismaModule, AuthModule, WishlistItemsModule, WishlistsModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/apps/api/src/auth/auth.constants.ts
+++ b/apps/api/src/auth/auth.constants.ts
@@ -1,0 +1,2 @@
+export const AUTH_COOKIE_NAME = 'wishlist_session';
+export const SESSION_DURATION_MS = 1000 * 60 * 60 * 24 * 7;

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -1,0 +1,72 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  Post,
+  Req,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
+import type { Request, Response } from 'express';
+import { AuthService } from './auth.service';
+import { AUTH_COOKIE_NAME, SESSION_DURATION_MS } from './auth.constants';
+import { CurrentUser } from './current-user.decorator';
+import { AuthGuard } from './auth.guard';
+import type { AuthenticatedUser } from './auth.types';
+import { parseCookieHeader } from './auth.utils';
+import { LoginDto } from './dto/login.dto';
+import { RegisterDto } from './dto/register.dto';
+
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  @Post('register')
+  async register(@Body() dto: RegisterDto) {
+    return this.authService.register(dto);
+  }
+
+  @Post('login')
+  async login(
+    @Body() dto: LoginDto,
+    @Res({ passthrough: true }) response: Response,
+  ) {
+    const result = await this.authService.login(dto);
+
+    response.cookie(AUTH_COOKIE_NAME, result.token, {
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+      maxAge: SESSION_DURATION_MS,
+      path: '/',
+    });
+
+    return {
+      user: result.user,
+      expiresAt: result.expiresAt,
+    };
+  }
+
+  @Post('logout')
+  @HttpCode(204)
+  async logout(
+    @Req() request: Request,
+    @Res({ passthrough: true }) response: Response,
+  ) {
+    const token = parseCookieHeader(request.headers.cookie)[AUTH_COOKIE_NAME];
+    await this.authService.logout(token);
+    response.clearCookie(AUTH_COOKIE_NAME, {
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+      path: '/',
+    });
+  }
+
+  @Get('me')
+  @UseGuards(AuthGuard)
+  getMe(@CurrentUser() user: AuthenticatedUser) {
+    return { user };
+  }
+}

--- a/apps/api/src/auth/auth.guard.ts
+++ b/apps/api/src/auth/auth.guard.ts
@@ -1,0 +1,48 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import type { Request } from 'express';
+import { PrismaService } from '../prisma/prisma.service';
+import { AUTH_COOKIE_NAME } from './auth.constants';
+import type { AuthenticatedRequest } from './auth.types';
+import { hashSessionToken, parseCookieHeader } from './auth.utils';
+
+@Injectable()
+export class AuthGuard implements CanActivate {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async canActivate(context: ExecutionContext) {
+    const request = context
+      .switchToHttp()
+      .getRequest<AuthenticatedRequest & Request>();
+    const cookies = parseCookieHeader(request.headers.cookie);
+    const token = cookies[AUTH_COOKIE_NAME];
+
+    if (!token) {
+      throw new UnauthorizedException('Authentication required');
+    }
+
+    const session = await this.prisma.session.findUnique({
+      where: { tokenHash: hashSessionToken(token) },
+      include: {
+        user: {
+          select: {
+            id: true,
+            email: true,
+            name: true,
+          },
+        },
+      },
+    });
+
+    if (!session || session.expiresAt <= new Date()) {
+      throw new UnauthorizedException('Authentication required');
+    }
+
+    request.user = session.user;
+    return true;
+  }
+}

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { AuthController } from './auth.controller';
+import { AuthGuard } from './auth.guard';
+import { AuthService } from './auth.service';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [AuthController],
+  providers: [AuthService, AuthGuard],
+  exports: [AuthGuard],
+})
+export class AuthModule {}

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,0 +1,106 @@
+import {
+  ConflictException,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { SESSION_DURATION_MS } from './auth.constants';
+import { LoginDto } from './dto/login.dto';
+import { RegisterDto } from './dto/register.dto';
+import {
+  createSessionToken,
+  hashPassword,
+  hashSessionToken,
+  verifyPassword,
+} from './auth.utils';
+
+@Injectable()
+export class AuthService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async register(dto: RegisterDto) {
+    const email = dto.email.trim().toLowerCase();
+    const existingUser = await this.prisma.user.findUnique({
+      where: { email },
+    });
+
+    if (existingUser) {
+      throw new ConflictException('An account with that email already exists');
+    }
+
+    const passwordHash = await hashPassword(dto.password);
+    const user = await this.prisma.user.create({
+      data: {
+        name: dto.name.trim(),
+        email,
+        passwordHash,
+        wishlists: {
+          create: {
+            title: `${dto.name.trim()}'s Wishlist`,
+          },
+        },
+      },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        createdAt: true,
+      },
+    });
+
+    return user;
+  }
+
+  async login(dto: LoginDto) {
+    const email = dto.email.trim().toLowerCase();
+    const user = await this.prisma.user.findUnique({
+      where: { email },
+    });
+
+    if (!user) {
+      throw new UnauthorizedException('Invalid email or password');
+    }
+
+    const isValid = await verifyPassword(dto.password, user.passwordHash);
+    if (!isValid) {
+      throw new UnauthorizedException('Invalid email or password');
+    }
+
+    await this.prisma.session.deleteMany({
+      where: {
+        userId: user.id,
+      },
+    });
+
+    const rawToken = createSessionToken();
+    const session = await this.prisma.session.create({
+      data: {
+        tokenHash: hashSessionToken(rawToken),
+        userId: user.id,
+        expiresAt: new Date(Date.now() + SESSION_DURATION_MS),
+      },
+    });
+
+    return {
+      token: rawToken,
+      expiresAt: session.expiresAt,
+      user: {
+        id: user.id,
+        name: user.name,
+        email: user.email,
+      },
+    };
+  }
+
+  async logout(rawToken?: string) {
+    if (!rawToken) {
+      return;
+    }
+
+    await this.prisma.session.deleteMany({
+      where: {
+        tokenHash: hashSessionToken(rawToken),
+      },
+    });
+  }
+}

--- a/apps/api/src/auth/auth.types.ts
+++ b/apps/api/src/auth/auth.types.ts
@@ -1,0 +1,9 @@
+export interface AuthenticatedUser {
+  id: number;
+  email: string;
+  name: string;
+}
+
+export interface AuthenticatedRequest extends Request {
+  user?: AuthenticatedUser;
+}

--- a/apps/api/src/auth/auth.utils.ts
+++ b/apps/api/src/auth/auth.utils.ts
@@ -1,0 +1,59 @@
+import {
+  randomBytes,
+  scrypt as nodeScrypt,
+  timingSafeEqual,
+  createHash,
+} from 'node:crypto';
+import { promisify } from 'node:util';
+
+const scrypt = promisify(nodeScrypt);
+
+export async function hashPassword(password: string) {
+  const salt = randomBytes(16).toString('hex');
+  const derivedKey = (await scrypt(password, salt, 64)) as Buffer;
+  return `${salt}:${derivedKey.toString('hex')}`;
+}
+
+export async function verifyPassword(password: string, passwordHash: string) {
+  const [salt, storedHash] = passwordHash.split(':');
+
+  if (!salt || !storedHash) {
+    return false;
+  }
+
+  const derivedKey = (await scrypt(password, salt, 64)) as Buffer;
+  const storedBuffer = Buffer.from(storedHash, 'hex');
+
+  if (storedBuffer.length !== derivedKey.length) {
+    return false;
+  }
+
+  return timingSafeEqual(storedBuffer, derivedKey);
+}
+
+export function createSessionToken() {
+  return randomBytes(32).toString('hex');
+}
+
+export function hashSessionToken(token: string) {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+export function parseCookieHeader(cookieHeader?: string | null) {
+  if (!cookieHeader) {
+    return {};
+  }
+
+  return cookieHeader
+    .split(';')
+    .reduce<Record<string, string>>((cookies, entry) => {
+      const [rawName, ...rawValue] = entry.trim().split('=');
+
+      if (!rawName || rawValue.length === 0) {
+        return cookies;
+      }
+
+      cookies[rawName] = decodeURIComponent(rawValue.join('='));
+      return cookies;
+    }, {});
+}

--- a/apps/api/src/auth/current-user.decorator.ts
+++ b/apps/api/src/auth/current-user.decorator.ts
@@ -1,0 +1,9 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import type { AuthenticatedRequest } from './auth.types';
+
+export const CurrentUser = createParamDecorator(
+  (_data: unknown, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest<AuthenticatedRequest>();
+    return request.user;
+  },
+);

--- a/apps/api/src/auth/dto/login.dto.ts
+++ b/apps/api/src/auth/dto/login.dto.ts
@@ -1,0 +1,10 @@
+import { IsEmail, IsString, MinLength } from 'class-validator';
+
+export class LoginDto {
+  @IsEmail()
+  email: string;
+
+  @IsString()
+  @MinLength(6)
+  password: string;
+}

--- a/apps/api/src/auth/dto/register.dto.ts
+++ b/apps/api/src/auth/dto/register.dto.ts
@@ -1,0 +1,14 @@
+import { IsEmail, IsNotEmpty, IsString, MinLength } from 'class-validator';
+
+export class RegisterDto {
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @IsEmail()
+  email: string;
+
+  @IsString()
+  @MinLength(6)
+  password: string;
+}

--- a/apps/api/src/wishlist-items/wishlist-items.controller.spec.ts
+++ b/apps/api/src/wishlist-items/wishlist-items.controller.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { Test, TestingModule } from '@nestjs/testing';
+import { AuthGuard } from '../auth/auth.guard';
 import { WishlistItemsController } from './wishlist-items.controller';
 import { WishlistItemsService } from './wishlist-items.service';
 
@@ -11,10 +12,14 @@ describe('WishlistItemsController', () => {
   } as unknown as WishlistItemsService;
 
   beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const moduleBuilder = Test.createTestingModule({
       controllers: [WishlistItemsController],
       providers: [{ provide: WishlistItemsService, useValue: serviceMock }],
-    }).compile();
+    })
+      .overrideGuard(AuthGuard)
+      .useValue({ canActivate: jest.fn(() => true) });
+
+    const module: TestingModule = await moduleBuilder.compile();
 
     controller = module.get<WishlistItemsController>(WishlistItemsController);
     jest.clearAllMocks();
@@ -27,9 +32,13 @@ describe('WishlistItemsController', () => {
   it('delegates deletion to the service and returns void', async () => {
     serviceMock.deleteWishlistItem = jest.fn().mockResolvedValue(undefined);
 
-    const result = await controller.deleteWishlistItem(42);
+    const result = await controller.deleteWishlistItem(42, {
+      id: 7,
+      name: 'Alice',
+      email: 'alice@example.com',
+    });
 
-    expect(serviceMock.deleteWishlistItem).toHaveBeenCalledWith(42);
+    expect(serviceMock.deleteWishlistItem).toHaveBeenCalledWith(42, 7);
     expect(result).toBeUndefined();
   });
 });

--- a/apps/api/src/wishlist-items/wishlist-items.controller.ts
+++ b/apps/api/src/wishlist-items/wishlist-items.controller.ts
@@ -7,10 +7,15 @@ import {
   Param,
   ParseIntPipe,
   Query,
+  UseGuards,
 } from '@nestjs/common';
+import { CurrentUser } from '../auth/current-user.decorator';
+import { AuthGuard } from '../auth/auth.guard';
+import type { AuthenticatedUser } from '../auth/auth.types';
 import { WishlistItemsService } from './wishlist-items.service';
 
 @Controller('wishlist-items')
+@UseGuards(AuthGuard)
 export class WishlistItemsController {
   constructor(private readonly wishlistItemsService: WishlistItemsService) {}
 
@@ -42,7 +47,10 @@ export class WishlistItemsController {
 
   @Delete(':id')
   @HttpCode(204)
-  deleteWishlistItem(@Param('id', ParseIntPipe) id: number) {
-    return this.wishlistItemsService.deleteWishlistItem(id);
+  deleteWishlistItem(
+    @Param('id', ParseIntPipe) id: number,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.wishlistItemsService.deleteWishlistItem(id, user.id);
   }
 }

--- a/apps/api/src/wishlist-items/wishlist-items.service.spec.ts
+++ b/apps/api/src/wishlist-items/wishlist-items.service.spec.ts
@@ -11,6 +11,7 @@ describe('WishlistItemsService', () => {
     wishlistItem: {
       findMany: jest.fn(),
       count: jest.fn(),
+      findUnique: jest.fn(),
       delete: jest.fn(),
     },
   } as unknown as PrismaService;
@@ -130,8 +131,17 @@ describe('WishlistItemsService', () => {
   it('deletes a wishlist item successfully', async () => {
     prismaMock.wishlistItem.delete = jest.fn().mockResolvedValue(undefined);
 
-    await expect(service.deleteWishlistItem(5)).resolves.toBeUndefined();
+    prismaMock.wishlistItem.findUnique = jest.fn().mockResolvedValue({
+      id: 5,
+      wishlist: { userId: 7 },
+    });
 
+    await expect(service.deleteWishlistItem(5, 7)).resolves.toBeUndefined();
+
+    expect(prismaMock.wishlistItem.findUnique).toHaveBeenCalledWith({
+      where: { id: 5 },
+      select: { id: true, wishlist: { select: { userId: true } } },
+    });
     expect(prismaMock.wishlistItem.delete).toHaveBeenCalledWith({
       where: { id: 5 },
     });
@@ -143,9 +153,13 @@ describe('WishlistItemsService', () => {
       clientVersion: 'test',
       meta: {},
     });
+    prismaMock.wishlistItem.findUnique = jest.fn().mockResolvedValue({
+      id: 999,
+      wishlist: { userId: 7 },
+    });
     prismaMock.wishlistItem.delete = jest.fn().mockRejectedValue(prismaError);
 
-    await expect(service.deleteWishlistItem(999)).rejects.toBeInstanceOf(
+    await expect(service.deleteWishlistItem(999, 7)).rejects.toBeInstanceOf(
       NotFoundException,
     );
   });

--- a/apps/api/src/wishlist-items/wishlist-items.service.ts
+++ b/apps/api/src/wishlist-items/wishlist-items.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 
@@ -70,11 +74,40 @@ export class WishlistItemsService {
     };
   }
 
-  async deleteWishlistItem(id: number) {
+  async deleteWishlistItem(id: number, currentUserId: number) {
     try {
+      const item = await this.prisma.wishlistItem.findUnique({
+        where: { id },
+        select: {
+          id: true,
+          wishlist: {
+            select: {
+              userId: true,
+            },
+          },
+        },
+      });
+
+      if (!item) {
+        throw new NotFoundException(`WishlistItem ${id} not found`);
+      }
+
+      if (item.wishlist.userId !== currentUserId) {
+        throw new ForbiddenException(
+          'You can only delete items from your own wishlist',
+        );
+      }
+
       await this.prisma.wishlistItem.delete({ where: { id } });
       return;
     } catch (err: any) {
+      if (
+        err instanceof NotFoundException ||
+        err instanceof ForbiddenException
+      ) {
+        throw err;
+      }
+
       if (
         err instanceof Prisma.PrismaClientKnownRequestError &&
         err.code === 'P2025'

--- a/apps/api/src/wishlists/wishlists.controller.spec.ts
+++ b/apps/api/src/wishlists/wishlists.controller.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { AuthGuard } from '../auth/auth.guard';
 import { WishlistsController } from './wishlists.controller';
 import { WishlistsService } from './wishlists.service';
 
@@ -9,10 +10,14 @@ describe('WishlistsController', () => {
   } as unknown as WishlistsService;
 
   beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const moduleBuilder = Test.createTestingModule({
       controllers: [WishlistsController],
       providers: [{ provide: WishlistsService, useValue: serviceMock }],
-    }).compile();
+    })
+      .overrideGuard(AuthGuard)
+      .useValue({ canActivate: jest.fn(() => true) });
+
+    const module: TestingModule = await moduleBuilder.compile();
 
     controller = module.get<WishlistsController>(WishlistsController);
   });

--- a/apps/api/src/wishlists/wishlists.controller.ts
+++ b/apps/api/src/wishlists/wishlists.controller.ts
@@ -1,15 +1,27 @@
-import { Body, Controller, Post, Param, ParseIntPipe } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Param,
+  ParseIntPipe,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import { WishlistsService } from './wishlists.service';
 import { CreateWishlistItemDto } from '../wishlist-items/dto/create-wishlist-item.dto';
+import { CurrentUser } from '../auth/current-user.decorator';
+import { AuthGuard } from '../auth/auth.guard';
+import type { AuthenticatedUser } from '../auth/auth.types';
 
 @Controller('wishlists')
+@UseGuards(AuthGuard)
 export class WishlistsController {
   constructor(private readonly wishlistsService: WishlistsService) {}
   @Post(':wishlistId/items')
   createWishlistItem(
     @Param('wishlistId', ParseIntPipe) wishlistId: number,
     @Body() dto: CreateWishlistItemDto,
+    @CurrentUser() user: AuthenticatedUser,
   ) {
-    return this.wishlistsService.createWishlistItem(wishlistId, dto);
+    return this.wishlistsService.createWishlistItem(wishlistId, dto, user.id);
   }
 }

--- a/apps/api/src/wishlists/wishlists.service.spec.ts
+++ b/apps/api/src/wishlists/wishlists.service.spec.ts
@@ -28,15 +28,18 @@ describe('WishlistsService', () => {
   });
 
   it('creates a wishlist item when the wishlist exists', async () => {
-    prismaMock.wishlist.findUnique = jest.fn().mockResolvedValue({ id: 1 });
+    prismaMock.wishlist.findUnique = jest
+      .fn()
+      .mockResolvedValue({ id: 1, userId: 3 });
     const createdItem = { id: 10, name: 'Book', wishlistId: 1 };
     prismaMock.wishlistItem.create = jest.fn().mockResolvedValue(createdItem);
 
     const dto = { name: 'Book', url: 'https://example.com', price: 25 };
-    const result = await service.createWishlistItem(1, dto);
+    const result = await service.createWishlistItem(1, dto, 3);
 
     expect(prismaMock.wishlist.findUnique).toHaveBeenCalledWith({
       where: { id: 1 },
+      select: { id: true, userId: true },
     });
     expect(prismaMock.wishlistItem.create).toHaveBeenCalledWith({
       data: {
@@ -51,11 +54,13 @@ describe('WishlistsService', () => {
   });
 
   it('trims the name before creating the item', async () => {
-    prismaMock.wishlist.findUnique = jest.fn().mockResolvedValue({ id: 2 });
+    prismaMock.wishlist.findUnique = jest
+      .fn()
+      .mockResolvedValue({ id: 2, userId: 8 });
     prismaMock.wishlistItem.create = jest.fn().mockResolvedValue({ id: 11 });
 
     const dto = { name: '   New Shoes   ' };
-    await service.createWishlistItem(2, dto);
+    await service.createWishlistItem(2, dto, 8);
 
     expect(prismaMock.wishlistItem.create).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -68,7 +73,7 @@ describe('WishlistsService', () => {
     prismaMock.wishlist.findUnique = jest.fn().mockResolvedValue(null);
 
     await expect(
-      service.createWishlistItem(99, { name: 'Gift' }),
+      service.createWishlistItem(99, { name: 'Gift' }, 3),
     ).rejects.toBeInstanceOf(NotFoundException);
 
     expect(prismaMock.wishlistItem.create).not.toHaveBeenCalled();

--- a/apps/api/src/wishlists/wishlists.service.ts
+++ b/apps/api/src/wishlists/wishlists.service.ts
@@ -1,17 +1,35 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateWishlistItemDto } from '../wishlist-items/dto/create-wishlist-item.dto';
 
 @Injectable()
 export class WishlistsService {
   constructor(private prisma: PrismaService) {}
-  async createWishlistItem(wishlistId: number, dto: CreateWishlistItemDto) {
+  async createWishlistItem(
+    wishlistId: number,
+    dto: CreateWishlistItemDto,
+    currentUserId: number,
+  ) {
     const wishlist = await this.prisma.wishlist.findUnique({
       where: { id: wishlistId },
+      select: {
+        id: true,
+        userId: true,
+      },
     });
 
     if (!wishlist) {
       throw new NotFoundException(`Wishlist ${wishlistId} not found`);
+    }
+
+    if (wishlist.userId !== currentUserId) {
+      throw new ForbiddenException(
+        'You can only add items to your own wishlist',
+      );
     }
 
     return this.prisma.wishlistItem.create({

--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -1,42 +1,80 @@
-#root {
-  max-width: 1280px;
+.app-shell,
+.auth-shell {
+  min-height: 100vh;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 3rem 1.5rem;
+}
+
+.app-shell {
   margin: 0 auto;
+  max-width: 960px;
+}
+
+.auth-shell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.auth-card {
+  width: min(100%, 420px);
+  border-radius: 24px;
   padding: 2rem;
-  text-align: center;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.18);
+  color: #1f2937;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.app-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 2rem;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+.eyebrow {
+  margin: 0 0 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: #2563eb;
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
+.subtle {
+  margin-top: 0.5rem;
+  color: #64748b;
 }
 
-.card {
-  padding: 2em;
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin: 1.5rem 0 1rem;
 }
 
-.read-the-docs {
-  color: #888;
+.auth-form input {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid #cbd5e1;
+  border-radius: 12px;
+  padding: 0.85rem 1rem;
+  font-size: 1rem;
+}
+
+.primary-action {
+  background: #2563eb;
+  color: #fff;
+}
+
+.secondary-action {
+  border: 1px solid #cbd5e1;
+  background: transparent;
+  color: #1f2937;
+}
+
+.form-error {
+  margin: 0;
+  color: #b91c1c;
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,22 +1,50 @@
-import { useCallback, useState, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import type { FormEvent } from 'react';
 import './App.css';
-import { getWishlistItems, deleteWishListItem } from './api/wishlistItems';
+import { getCurrentUser, login, logout, register } from './api/auth';
+import { deleteWishListItem, getWishlistItems } from './api/wishlistItems';
 import { Card, DropDown, PaginationButtons, UserSearch } from './components/index';
-import type { WishlistItemResponse, PaginationMeta } from './types/wishlist';
+import type { AuthUser, PaginationMeta, WishlistItemResponse } from './types/wishlist';
 
 const DEFAULT_LIMIT = 10;
 
 function App() {
-  const [loading, setLoading] = useState<boolean>(false);
+  const [authMode, setAuthMode] = useState<'login' | 'register'>('login');
+  const [currentUser, setCurrentUser] = useState<AuthUser | null>(null);
+  const [authLoading, setAuthLoading] = useState(true);
+  const [authError, setAuthError] = useState<string | null>(null);
+  const [authForm, setAuthForm] = useState({
+    name: '',
+    email: '',
+    password: '',
+  });
+  const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [wishlistItems, setWishlistItems] = useState<WishlistItemResponse[]>([]);
-  const [inputUserName, setInputUserName] = useState<string>('');
-  const [searchUserName, setSearchUserName] = useState<string>('');
-  const [currentPage, setCurrentPage] = useState<number>(1);
+  const [inputUserName, setInputUserName] = useState('');
+  const [searchUserName, setSearchUserName] = useState('');
+  const [currentPage, setCurrentPage] = useState(1);
   const [meta, setMeta] = useState<PaginationMeta>();
-  const [limit, setLimit] = useState<number>(DEFAULT_LIMIT);
+  const [limit, setLimit] = useState(DEFAULT_LIMIT);
+
+  const bootstrapUser = useCallback(async () => {
+    setAuthLoading(true);
+    try {
+      const response = await getCurrentUser();
+      setCurrentUser(response.user);
+      setAuthError(null);
+    } catch {
+      setCurrentUser(null);
+    } finally {
+      setAuthLoading(false);
+    }
+  }, []);
 
   const fetchData = useCallback(async () => {
+    if (!currentUser) {
+      return;
+    }
+
     setLoading(true);
     setError(null);
     try {
@@ -25,79 +53,220 @@ function App() {
       setMeta(res.meta);
     } catch (err) {
       console.error(err);
-      setError('Failed to load wishlist items');
+      setError(err instanceof Error ? err.message : 'Failed to load wishlist items');
     } finally {
       setLoading(false);
     }
-  }, [currentPage, limit]);
+  }, [currentPage, currentUser, limit]);
 
   useEffect(() => {
-    void fetchData();
-  }, [fetchData]);
+    void bootstrapUser();
+  }, [bootstrapUser]);
+
+  useEffect(() => {
+    if (currentUser) {
+      void fetchData();
+    }
+  }, [currentUser, fetchData]);
 
   const handleBackPage = () => {
-    setCurrentPage((p) => Math.max(1, p - 1));
+    setCurrentPage((page) => Math.max(1, page - 1));
   };
 
   const handleNextPage = () => {
-    setCurrentPage((p) => p + 1);
+    setCurrentPage((page) => page + 1);
   };
 
   const onDeleteItem = useCallback(
     async (id: number) => {
-      await deleteWishListItem(id);
-      await fetchData();
+      try {
+        await deleteWishListItem(id);
+        await fetchData();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to delete wishlist item');
+      }
     },
     [fetchData],
   );
 
   const handleSearchSubmit = () => {
     setSearchUserName(inputUserName.trim());
-    console.log(`eventually searching for: ${searchUserName}`);
   };
-  return (
-    <>
-      <div className="min-h-screen flex flex-col items-center py-16 px-4">
-        <h1 className="text-5xl font-light text-gray-200 mb-12">Wishlists</h1>
-        <h2>{loading && 'loading...'}</h2>
-        {error ? (
-          <div>
-            <h2>{error}</h2>
-          </div>
-        ) : (
-          <div className="flex flex-col items-center">
-            <UserSearch
-              onSubmit={handleSearchSubmit}
-              value={inputUserName}
-              onChange={setInputUserName}
+
+  const filteredItems = wishlistItems.filter((item) =>
+    !searchUserName
+      ? true
+      : item.ownerName.toLowerCase().includes(searchUserName.toLowerCase()) ||
+        item.name.toLowerCase().includes(searchUserName.toLowerCase()) ||
+        item.wishlistTitle.toLowerCase().includes(searchUserName.toLowerCase()),
+  );
+
+  const handleAuthSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setAuthError(null);
+
+    try {
+      const normalizedEmail = authForm.email.trim().toLowerCase();
+
+      if (authMode === 'register') {
+        await register({
+          name: authForm.name.trim(),
+          email: normalizedEmail,
+          password: authForm.password,
+        });
+      }
+
+      const response = await login({
+        email: normalizedEmail,
+        password: authForm.password,
+      });
+
+      setCurrentUser(response.user);
+      setAuthForm({ name: '', email: '', password: '' });
+      setCurrentPage(1);
+      setError(null);
+    } catch (err) {
+      setAuthError(err instanceof Error ? err.message : 'Unable to authenticate right now');
+    }
+  };
+
+  const handleLogout = async () => {
+    try {
+      await logout();
+    } finally {
+      setCurrentUser(null);
+      setWishlistItems([]);
+      setMeta(undefined);
+      setError(null);
+      setAuthError(null);
+    }
+  };
+
+  if (authLoading) {
+    return <div className="app-shell">Checking your session...</div>;
+  }
+
+  if (!currentUser) {
+    return (
+      <div className="auth-shell">
+        <div className="auth-card">
+          <p className="eyebrow">Wishlist</p>
+          <h1>{authMode === 'login' ? 'Sign in' : 'Create account'}</h1>
+          <p className="subtle">Sign in to browse wishlists and manage your own items.</p>
+          <form
+            className="auth-form"
+            onSubmit={(event) => {
+              void handleAuthSubmit(event);
+            }}
+          >
+            {authMode === 'register' && (
+              <input
+                type="text"
+                placeholder="Name"
+                value={authForm.name}
+                onChange={(event) =>
+                  setAuthForm((current) => ({
+                    ...current,
+                    name: event.target.value,
+                  }))
+                }
+              />
+            )}
+            <input
+              type="email"
+              placeholder="Email"
+              value={authForm.email}
+              onChange={(event) =>
+                setAuthForm((current) => ({
+                  ...current,
+                  email: event.target.value,
+                }))
+              }
             />
-            <div className="w-full max-w-md space-y-6">
-              {wishlistItems.map((item: WishlistItemResponse) => (
-                <Card
-                  {...item}
-                  key={item.id}
-                  onDelete={(id) => {
-                    void onDeleteItem(id);
-                  }}
-                />
-              ))}
-            </div>
-            <PaginationButtons
-              handleBackPage={handleBackPage}
-              handleNextPage={handleNextPage}
-              currentPage={currentPage}
-              totalPages={meta?.totalPages}
+            <input
+              type="password"
+              placeholder="Password"
+              value={authForm.password}
+              onChange={(event) =>
+                setAuthForm((current) => ({
+                  ...current,
+                  password: event.target.value,
+                }))
+              }
             />
-            <DropDown
-              limit={limit}
-              setLimit={setLimit}
-              setCurrentPage={setCurrentPage}
-              totalItems={meta?.total}
-            />
-          </div>
-        )}
+            {authError && <p className="form-error">{authError}</p>}
+            <button type="submit" className="primary-action">
+              {authMode === 'login' ? 'Sign in' : 'Register and sign in'}
+            </button>
+          </form>
+          <button
+            className="secondary-action"
+            onClick={() => setAuthMode((current) => (current === 'login' ? 'register' : 'login'))}
+          >
+            {authMode === 'login'
+              ? 'Need an account? Register'
+              : 'Already have an account? Sign in'}
+          </button>
+        </div>
       </div>
-    </>
+    );
+  }
+
+  return (
+    <div className="app-shell">
+      <div className="app-header">
+        <div>
+          <p className="eyebrow">Wishlist</p>
+          <h1>Wishlists</h1>
+          <p className="subtle">Signed in as {currentUser.name}</p>
+        </div>
+        <button className="secondary-action" onClick={() => void handleLogout()}>
+          Sign out
+        </button>
+      </div>
+      {loading && <h2>Loading...</h2>}
+      {error ? (
+        <div>
+          <h2>{error}</h2>
+        </div>
+      ) : (
+        <div className="flex flex-col items-center">
+          <UserSearch
+            onSubmit={handleSearchSubmit}
+            value={inputUserName}
+            onChange={setInputUserName}
+          />
+          <div className="w-full max-w-md space-y-6">
+            {filteredItems.map((item) => (
+              <Card
+                {...item}
+                key={item.id}
+                onDelete={(id) => {
+                  if (item.ownerId !== currentUser.id) {
+                    setError('You can only delete items from your own wishlist.');
+                    return;
+                  }
+
+                  void onDeleteItem(id);
+                }}
+              />
+            ))}
+          </div>
+          <PaginationButtons
+            handleBackPage={handleBackPage}
+            handleNextPage={handleNextPage}
+            currentPage={currentPage}
+            totalPages={meta?.totalPages}
+          />
+          <DropDown
+            limit={limit}
+            setLimit={setLimit}
+            setCurrentPage={setCurrentPage}
+            totalItems={meta?.total}
+          />
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/apps/web/src/api/auth.ts
+++ b/apps/web/src/api/auth.ts
@@ -1,0 +1,61 @@
+import type { AuthUser } from '../types/wishlist';
+
+const BASE_URL = 'http://localhost:3000';
+
+type AuthPayload = {
+  email: string;
+  password: string;
+  name?: string;
+};
+
+async function apiRequest<T>(path: string, init?: RequestInit) {
+  const response = await fetch(`${BASE_URL}${path}`, {
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(init?.headers ?? {}),
+    },
+    ...init,
+  });
+
+  if (!response.ok) {
+    const data = (await response.json().catch(() => null)) as {
+      message?: string;
+      error?: string;
+    } | null;
+    throw new Error(data?.message ?? data?.error ?? 'Request failed');
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  return (await response.json()) as T;
+}
+
+export function getCurrentUser() {
+  return apiRequest<AuthResponse>('/api/auth/me');
+}
+
+export function register(payload: AuthPayload) {
+  return apiRequest('/api/auth/register', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}
+
+export function login(payload: AuthPayload) {
+  return apiRequest<AuthResponse>('/api/auth/login', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}
+
+export function logout() {
+  return apiRequest<void>('/api/auth/logout', {
+    method: 'POST',
+  });
+}
+type AuthResponse = {
+  user: AuthUser;
+};

--- a/apps/web/src/api/wishlistItems.tsx
+++ b/apps/web/src/api/wishlistItems.tsx
@@ -16,7 +16,9 @@ export async function getWishlistItems(
     params.append(`userId`, String(userId));
   }
 
-  const response = await fetch(`${BASE_URL}/api/wishlist-items?${params.toString()}`);
+  const response = await fetch(`${BASE_URL}/api/wishlist-items?${params.toString()}`, {
+    credentials: 'include',
+  });
 
   if (!response.ok) {
     throw new Error('Failed to fetch wishlist items');
@@ -25,7 +27,10 @@ export async function getWishlistItems(
 }
 
 export async function deleteWishListItem(itemId: number) {
-  const response = await fetch(`${BASE_URL}/api/wishlist-items/${itemId}`, { method: 'DELETE' });
+  const response = await fetch(`${BASE_URL}/api/wishlist-items/${itemId}`, {
+    method: 'DELETE',
+    credentials: 'include',
+  });
 
   if (!response.ok) {
     throw new Error(`Failed to delete itemId: ${itemId}`);

--- a/apps/web/src/components/Card.tsx
+++ b/apps/web/src/components/Card.tsx
@@ -24,9 +24,16 @@ const Card = (item: CardProps) => {
 
         <div className="flex items-center justify-between pt-4 border-t border-gray-100">
           <span className="text-sm text-gray-500">Price</span>
-          <span className="text-xl font-bold text-gray-900">{item.price}</span>
+          <span className="text-xl font-bold text-gray-900">
+            {item.price == null ? 'N/A' : `$${item.price}`}
+          </span>
         </div>
-        <button onClick={() => handleClick(item.id)}>Delete</button>
+        <button
+          className="self-end rounded-md bg-red-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-red-700"
+          onClick={() => handleClick(item.id)}
+        >
+          Delete
+        </button>
       </div>
     </div>
   );

--- a/apps/web/src/components/UserSearch.tsx
+++ b/apps/web/src/components/UserSearch.tsx
@@ -5,7 +5,7 @@ interface UserSearchPropsType {
 }
 
 const UserSearch = ({ onChange, onSubmit, value }: UserSearchPropsType) => {
-  const handleSubmit = (e: React.ChangeEvent<HTMLFormElement>) => {
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     onSubmit();
   };

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -3,13 +3,13 @@
 @tailwind utilities;
 
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color: #0f172a;
+  background:
+    radial-gradient(circle at top, rgba(37, 99, 235, 0.22), transparent 45%),
+    linear-gradient(180deg, #f8fafc 0%, #dbeafe 100%);
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -19,17 +19,15 @@
 
 a {
   font-weight: 500;
-  color: #646cff;
+  color: #2563eb;
   text-decoration: inherit;
 }
 a:hover {
-  color: #535bf2;
+  color: #1d4ed8;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }
@@ -37,6 +35,7 @@ body {
 h1 {
   font-size: 3.2em;
   line-height: 1.1;
+  margin: 0;
 }
 
 button {
@@ -46,27 +45,14 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: #ffffff;
   cursor: pointer;
   transition: border-color 0.25s;
 }
 button:hover {
-  border-color: #646cff;
+  border-color: #2563eb;
 }
 button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
 }

--- a/apps/web/src/types/wishlist.tsx
+++ b/apps/web/src/types/wishlist.tsx
@@ -6,6 +6,12 @@ import type {
 
 export type { WishlistItemResponse, PaginationMeta, PaginatedWishlistItems };
 
+export interface AuthUser {
+  id: number;
+  email: string;
+  name: string;
+}
+
 export interface CardProps extends WishlistItemResponse {
   onDelete: (id: number) => void;
 }

--- a/packages/shared/dist/index.d.ts
+++ b/packages/shared/dist/index.d.ts
@@ -23,3 +23,11 @@ export type PaginatedWishlistItems = {
     data: WishlistItemResponse[];
     meta: PaginationMeta;
 };
+export type AuthUser = {
+    id: number;
+    email: string;
+    name: string;
+};
+export type AuthResponse = {
+    user: AuthUser;
+};

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -27,3 +27,13 @@ export type PaginatedWishlistItems = {
   data: WishlistItemResponse[];
   meta: PaginationMeta;
 };
+
+export type AuthUser = {
+  id: number;
+  email: string;
+  name: string;
+};
+
+export type AuthResponse = {
+  user: AuthUser;
+};


### PR DESCRIPTION
## Summary
- add Nest auth endpoints for register, login, logout, and current user with cookie-backed sessions
- protect wishlist reads and owner-only mutations with an auth guard
- add React auth UI and session bootstrap to the Vite web app
- update Prisma schema and migration for password hashes and sessions

## Verification
- npm run build -w apps/api
- npm run build -w apps/web
- npx eslint apps/api/src/**/*.ts apps/api/test/**/*.ts apps/web/src/**/*.tsx apps/web/src/**/*.ts
- npm test -w apps/api -- --runInBand
- DATABASE_URL="file:./prisma/dev.db" npx prisma migrate deploy --schema prisma/schema.prisma