### PR TITLE
Add password reset and family memberships

### DIFF
--- a/apps/api/.gitignore
+++ b/apps/api/.gitignore
@@ -56,3 +56,4 @@ pids
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
 /generated/prisma
+/prisma/prisma

--- a/apps/api/prisma/migrations/20260325010000_add_password_reset_and_families/migration.sql
+++ b/apps/api/prisma/migrations/20260325010000_add_password_reset_and_families/migration.sql
@@ -1,0 +1,40 @@
+-- CreateTable
+CREATE TABLE "PasswordResetToken" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "tokenHash" TEXT NOT NULL,
+    "expiresAt" DATETIME NOT NULL,
+    "usedAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "userId" INTEGER NOT NULL,
+    CONSTRAINT "PasswordResetToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "Family" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "name" TEXT NOT NULL,
+    "joinCode" TEXT NOT NULL,
+    "creatorId" INTEGER NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Family_creatorId_fkey" FOREIGN KEY ("creatorId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "FamilyMembership" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "userId" INTEGER NOT NULL,
+    "familyId" INTEGER NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "FamilyMembership_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "FamilyMembership_familyId_fkey" FOREIGN KEY ("familyId") REFERENCES "Family" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PasswordResetToken_tokenHash_key" ON "PasswordResetToken"("tokenHash");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Family_joinCode_key" ON "Family"("joinCode");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FamilyMembership_userId_familyId_key" ON "FamilyMembership"("userId", "familyId");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -11,14 +11,17 @@ datasource db {
 }
 
 model User {
-  id           Int       @id @default(autoincrement())
-  name         String
-  email        String    @unique
-  passwordHash String
-  sessions     Session[]
-  wishlists    Wishlist[]
-  createdAt    DateTime  @default(now())
-  updatedAt    DateTime  @updatedAt
+  id                  Int                  @id @default(autoincrement())
+  name                String
+  email               String               @unique
+  passwordHash        String
+  sessions            Session[]
+  passwordResetTokens PasswordResetToken[]
+  memberships         FamilyMembership[]
+  createdFamilies     Family[]             @relation("FamilyCreator")
+  wishlists           Wishlist[]
+  createdAt           DateTime             @default(now())
+  updatedAt           DateTime             @updatedAt
 }
 
 model Session {
@@ -28,6 +31,38 @@ model Session {
   createdAt DateTime @default(now())
   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId    Int
+}
+
+model PasswordResetToken {
+  id        Int       @id @default(autoincrement())
+  tokenHash String    @unique
+  expiresAt DateTime
+  usedAt    DateTime?
+  createdAt DateTime  @default(now())
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId    Int
+}
+
+model Family {
+  id          Int                @id @default(autoincrement())
+  name        String
+  joinCode    String             @unique
+  creator     User               @relation("FamilyCreator", fields: [creatorId], references: [id], onDelete: Cascade)
+  creatorId   Int
+  memberships FamilyMembership[]
+  createdAt   DateTime           @default(now())
+  updatedAt   DateTime           @updatedAt
+}
+
+model FamilyMembership {
+  id        Int      @id @default(autoincrement())
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId    Int
+  family    Family   @relation(fields: [familyId], references: [id], onDelete: Cascade)
+  familyId  Int
+  createdAt DateTime @default(now())
+
+  @@unique([userId, familyId])
 }
 
 model Wishlist {

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -50,6 +50,17 @@ async function main() {
     },
   });
 
+  await prisma.family.create({
+    data: {
+      name: 'Tiller Family',
+      joinCode: 'FAMILY1',
+      creatorId: user1.id,
+      memberships: {
+        create: [{ userId: user1.id }, { userId: user2.id }],
+      },
+    },
+  });
+
   console.log('Seeded:', user1.name, user2.name);
 }
 

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -2,12 +2,19 @@ import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
+import { FamiliesModule } from './families/families.module';
 import { PrismaModule } from './prisma/prisma.module';
 import { WishlistItemsModule } from './wishlist-items/wishlist-items.module';
 import { WishlistsModule } from './wishlists/wishlists.module';
 
 @Module({
-  imports: [PrismaModule, AuthModule, WishlistItemsModule, WishlistsModule],
+  imports: [
+    PrismaModule,
+    AuthModule,
+    FamiliesModule,
+    WishlistItemsModule,
+    WishlistsModule,
+  ],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/apps/api/src/auth/auth.constants.ts
+++ b/apps/api/src/auth/auth.constants.ts
@@ -1,2 +1,3 @@
 export const AUTH_COOKIE_NAME = 'wishlist_session';
 export const SESSION_DURATION_MS = 1000 * 60 * 60 * 24 * 7;
+export const PASSWORD_RESET_DURATION_MS = 1000 * 60 * 30;

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -15,8 +15,10 @@ import { CurrentUser } from './current-user.decorator';
 import { AuthGuard } from './auth.guard';
 import type { AuthenticatedUser } from './auth.types';
 import { parseCookieHeader } from './auth.utils';
+import { ForgotPasswordDto } from './dto/forgot-password.dto';
 import { LoginDto } from './dto/login.dto';
 import { RegisterDto } from './dto/register.dto';
+import { ResetPasswordDto } from './dto/reset-password.dto';
 
 @Controller('auth')
 export class AuthController {
@@ -46,6 +48,16 @@ export class AuthController {
       user: result.user,
       expiresAt: result.expiresAt,
     };
+  }
+
+  @Post('forgot-password')
+  async forgotPassword(@Body() dto: ForgotPasswordDto) {
+    return this.authService.forgotPassword(dto);
+  }
+
+  @Post('reset-password')
+  async resetPassword(@Body() dto: ResetPasswordDto) {
+    return this.authService.resetPassword(dto);
   }
 
   @Post('logout')

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -1,0 +1,149 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/unbound-method */
+import { BadRequestException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from '../prisma/prisma.service';
+import { AuthService } from './auth.service';
+import { hashSessionToken } from './auth.utils';
+
+describe('AuthService', () => {
+  let service: AuthService;
+  const prismaMock = {
+    user: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+    passwordResetToken: {
+      deleteMany: jest.fn(),
+      create: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+    session: {
+      deleteMany: jest.fn(),
+    },
+    $transaction: jest.fn(),
+  } as unknown as PrismaService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthService,
+        { provide: PrismaService, useValue: prismaMock },
+      ],
+    }).compile();
+
+    service = module.get<AuthService>(AuthService);
+    jest.clearAllMocks();
+  });
+
+  it('returns a generic forgot-password response for unknown emails', async () => {
+    prismaMock.user.findUnique = jest.fn().mockResolvedValue(null);
+
+    const result = await service.forgotPassword({
+      email: 'missing@example.com',
+    });
+
+    expect(result).toEqual({
+      message:
+        'If an account exists for that email, a reset token has been generated.',
+    });
+    expect(prismaMock.passwordResetToken.create).not.toHaveBeenCalled();
+  });
+
+  it('returns a development reset token for known emails', async () => {
+    prismaMock.user.findUnique = jest.fn().mockResolvedValue({ id: 3 });
+    prismaMock.passwordResetToken.deleteMany = jest.fn().mockResolvedValue({
+      count: 0,
+    });
+    prismaMock.passwordResetToken.create = jest.fn().mockResolvedValue({
+      id: 1,
+      expiresAt: new Date('2026-03-25T12:00:00.000Z'),
+    });
+
+    const result = await service.forgotPassword({ email: 'alice@example.com' });
+
+    expect(prismaMock.passwordResetToken.deleteMany).toHaveBeenCalledWith({
+      where: { userId: 3 },
+    });
+    expect(prismaMock.passwordResetToken.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          userId: 3,
+        }),
+      }),
+    );
+    expect(result).toEqual(
+      expect.objectContaining({
+        message:
+          'If an account exists for that email, a reset token has been generated.',
+        resetToken: expect.any(String),
+        expiresAt: new Date('2026-03-25T12:00:00.000Z'),
+      }),
+    );
+  });
+
+  it('resets the password and invalidates sessions for a valid token', async () => {
+    const token = 'raw-reset-token';
+    const existingToken = {
+      id: 10,
+      tokenHash: hashSessionToken(token),
+      usedAt: null,
+      expiresAt: new Date(Date.now() + 60_000),
+      user: {
+        id: 7,
+      },
+    };
+
+    prismaMock.passwordResetToken.findUnique = jest
+      .fn()
+      .mockResolvedValue(existingToken);
+    prismaMock.user.update = jest.fn().mockResolvedValue(undefined);
+    prismaMock.passwordResetToken.update = jest
+      .fn()
+      .mockResolvedValue(undefined);
+    prismaMock.passwordResetToken.deleteMany = jest.fn().mockResolvedValue({
+      count: 0,
+    });
+    prismaMock.session.deleteMany = jest.fn().mockResolvedValue({ count: 3 });
+    prismaMock.$transaction = jest
+      .fn()
+      .mockImplementation(async (operations: Promise<unknown>[]) =>
+        Promise.all(operations),
+      );
+
+    const result = await service.resetPassword({
+      token,
+      password: 'new-password-123',
+    });
+
+    expect(prismaMock.passwordResetToken.findUnique).toHaveBeenCalledWith({
+      where: {
+        tokenHash: hashSessionToken(token),
+      },
+      include: {
+        user: {
+          select: {
+            id: true,
+          },
+        },
+      },
+    });
+    expect(prismaMock.$transaction).toHaveBeenCalled();
+    expect(result).toEqual({
+      message: 'Password reset successfully.',
+    });
+  });
+
+  it('rejects an expired or invalid reset token', async () => {
+    prismaMock.passwordResetToken.findUnique = jest
+      .fn()
+      .mockResolvedValue(null);
+
+    await expect(
+      service.resetPassword({
+        token: 'bad-token',
+        password: 'new-password-123',
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+});

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,13 +1,20 @@
 import {
+  BadRequestException,
   ConflictException,
   Injectable,
   UnauthorizedException,
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
-import { SESSION_DURATION_MS } from './auth.constants';
+import {
+  PASSWORD_RESET_DURATION_MS,
+  SESSION_DURATION_MS,
+} from './auth.constants';
+import { ForgotPasswordDto } from './dto/forgot-password.dto';
 import { LoginDto } from './dto/login.dto';
 import { RegisterDto } from './dto/register.dto';
+import { ResetPasswordDto } from './dto/reset-password.dto';
 import {
+  createResetToken,
   createSessionToken,
   hashPassword,
   hashSessionToken,
@@ -89,6 +96,110 @@ export class AuthService {
         name: user.name,
         email: user.email,
       },
+    };
+  }
+
+  async forgotPassword(dto: ForgotPasswordDto) {
+    const email = dto.email.trim().toLowerCase();
+    const user = await this.prisma.user.findUnique({
+      where: { email },
+      select: {
+        id: true,
+      },
+    });
+
+    if (!user) {
+      return {
+        message:
+          'If an account exists for that email, a reset token has been generated.',
+      };
+    }
+
+    await this.prisma.passwordResetToken.deleteMany({
+      where: {
+        userId: user.id,
+      },
+    });
+
+    const rawToken = createResetToken();
+    const resetToken = await this.prisma.passwordResetToken.create({
+      data: {
+        tokenHash: hashSessionToken(rawToken),
+        userId: user.id,
+        expiresAt: new Date(Date.now() + PASSWORD_RESET_DURATION_MS),
+      },
+    });
+
+    return {
+      message:
+        'If an account exists for that email, a reset token has been generated.',
+      ...(process.env.NODE_ENV !== 'production'
+        ? {
+            resetToken: rawToken,
+            expiresAt: resetToken.expiresAt,
+          }
+        : {}),
+    };
+  }
+
+  async resetPassword(dto: ResetPasswordDto) {
+    const passwordResetToken = await this.prisma.passwordResetToken.findUnique({
+      where: {
+        tokenHash: hashSessionToken(dto.token),
+      },
+      include: {
+        user: {
+          select: {
+            id: true,
+          },
+        },
+      },
+    });
+
+    if (
+      !passwordResetToken ||
+      passwordResetToken.usedAt ||
+      passwordResetToken.expiresAt <= new Date()
+    ) {
+      throw new BadRequestException('Reset token is invalid or expired');
+    }
+
+    const passwordHash = await hashPassword(dto.password);
+
+    await this.prisma.$transaction([
+      this.prisma.user.update({
+        where: {
+          id: passwordResetToken.user.id,
+        },
+        data: {
+          passwordHash,
+        },
+      }),
+      this.prisma.passwordResetToken.update({
+        where: {
+          id: passwordResetToken.id,
+        },
+        data: {
+          usedAt: new Date(),
+        },
+      }),
+      this.prisma.passwordResetToken.deleteMany({
+        where: {
+          userId: passwordResetToken.user.id,
+          id: {
+            not: passwordResetToken.id,
+          },
+        },
+      }),
+      this.prisma.session.deleteMany({
+        where: {
+          userId: passwordResetToken.user.id,
+        },
+      }),
+    ]);
+
+    return {
+      message: 'Password reset successfully.',
     };
   }
 

--- a/apps/api/src/auth/auth.utils.ts
+++ b/apps/api/src/auth/auth.utils.ts
@@ -35,6 +35,14 @@ export function createSessionToken() {
   return randomBytes(32).toString('hex');
 }
 
+export function createResetToken() {
+  return randomBytes(32).toString('hex');
+}
+
+export function createJoinCode() {
+  return randomBytes(4).toString('hex').toUpperCase();
+}
+
 export function hashSessionToken(token: string) {
   return createHash('sha256').update(token).digest('hex');
 }

--- a/apps/api/src/auth/dto/forgot-password.dto.ts
+++ b/apps/api/src/auth/dto/forgot-password.dto.ts
@@ -1,0 +1,6 @@
+import { IsEmail } from 'class-validator';
+
+export class ForgotPasswordDto {
+  @IsEmail()
+  email: string;
+}

--- a/apps/api/src/auth/dto/reset-password.dto.ts
+++ b/apps/api/src/auth/dto/reset-password.dto.ts
@@ -1,0 +1,10 @@
+import { IsString, MinLength } from 'class-validator';
+
+export class ResetPasswordDto {
+  @IsString()
+  token: string;
+
+  @IsString()
+  @MinLength(6)
+  password: string;
+}

--- a/apps/api/src/families/dto/create-family.dto.ts
+++ b/apps/api/src/families/dto/create-family.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class CreateFamilyDto {
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+}

--- a/apps/api/src/families/dto/join-family.dto.ts
+++ b/apps/api/src/families/dto/join-family.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class JoinFamilyDto {
+  @IsString()
+  @IsNotEmpty()
+  joinCode: string;
+}

--- a/apps/api/src/families/families.controller.ts
+++ b/apps/api/src/families/families.controller.ts
@@ -1,0 +1,34 @@
+import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
+import { AuthGuard } from '../auth/auth.guard';
+import { CurrentUser } from '../auth/current-user.decorator';
+import type { AuthenticatedUser } from '../auth/auth.types';
+import { FamiliesService } from './families.service';
+import { CreateFamilyDto } from './dto/create-family.dto';
+import { JoinFamilyDto } from './dto/join-family.dto';
+
+@Controller('families')
+@UseGuards(AuthGuard)
+export class FamiliesController {
+  constructor(private readonly familiesService: FamiliesService) {}
+
+  @Get()
+  listFamilies(@CurrentUser() user: AuthenticatedUser) {
+    return this.familiesService.listFamilies(user.id);
+  }
+
+  @Post()
+  createFamily(
+    @CurrentUser() user: AuthenticatedUser,
+    @Body() dto: CreateFamilyDto,
+  ) {
+    return this.familiesService.createFamily(user.id, dto);
+  }
+
+  @Post('join')
+  joinFamily(
+    @CurrentUser() user: AuthenticatedUser,
+    @Body() dto: JoinFamilyDto,
+  ) {
+    return this.familiesService.joinFamily(user.id, dto);
+  }
+}

--- a/apps/api/src/families/families.module.ts
+++ b/apps/api/src/families/families.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { FamiliesController } from './families.controller';
+import { FamiliesService } from './families.service';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [FamiliesController],
+  providers: [FamiliesService],
+  exports: [FamiliesService],
+})
+export class FamiliesModule {}

--- a/apps/api/src/families/families.service.spec.ts
+++ b/apps/api/src/families/families.service.spec.ts
@@ -1,0 +1,168 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/unbound-method */
+import {
+  ConflictException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from '../prisma/prisma.service';
+import { FamiliesService } from './families.service';
+
+describe('FamiliesService', () => {
+  let service: FamiliesService;
+  const prismaMock = {
+    family: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+    },
+    familyMembership: {
+      findMany: jest.fn(),
+      findFirst: jest.fn(),
+      create: jest.fn(),
+    },
+  } as unknown as PrismaService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FamiliesService,
+        { provide: PrismaService, useValue: prismaMock },
+      ],
+    }).compile();
+
+    service = module.get<FamiliesService>(FamiliesService);
+    jest.clearAllMocks();
+  });
+
+  it('creates a family and adds the creator as a member', async () => {
+    prismaMock.family.findUnique = jest.fn().mockResolvedValue(null);
+    prismaMock.family.create = jest.fn().mockResolvedValue({
+      id: 1,
+      name: 'Smith Family',
+      joinCode: 'ABCD1234',
+      creatorId: 7,
+      createdAt: new Date('2026-03-25T10:00:00.000Z'),
+      updatedAt: new Date('2026-03-25T10:00:00.000Z'),
+      memberships: [
+        {
+          user: {
+            id: 7,
+            name: 'Alice',
+            email: 'alice@example.com',
+          },
+        },
+      ],
+    });
+
+    const result = await service.createFamily(7, { name: 'Smith Family' });
+
+    expect(prismaMock.family.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          creatorId: 7,
+          name: 'Smith Family',
+          memberships: {
+            create: {
+              userId: 7,
+            },
+          },
+        }),
+      }),
+    );
+    expect(result.memberCount).toBe(1);
+  });
+
+  it('joins a family by join code', async () => {
+    prismaMock.family.findUnique = jest.fn().mockResolvedValue({
+      id: 1,
+      name: 'Smith Family',
+      joinCode: 'ABCD1234',
+      creatorId: 7,
+      memberships: [
+        {
+          userId: 7,
+          user: {
+            id: 7,
+            name: 'Alice',
+            email: 'alice@example.com',
+          },
+        },
+      ],
+    });
+    prismaMock.familyMembership.create = jest.fn().mockResolvedValue({
+      family: {
+        id: 1,
+        name: 'Smith Family',
+        joinCode: 'ABCD1234',
+        creatorId: 7,
+        createdAt: new Date('2026-03-25T10:00:00.000Z'),
+        updatedAt: new Date('2026-03-25T10:05:00.000Z'),
+        memberships: [
+          {
+            user: {
+              id: 7,
+              name: 'Alice',
+              email: 'alice@example.com',
+            },
+          },
+          {
+            user: {
+              id: 9,
+              name: 'Bob',
+              email: 'bob@example.com',
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await service.joinFamily(9, { joinCode: 'abcd1234' });
+
+    expect(prismaMock.family.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { joinCode: 'ABCD1234' },
+      }),
+    );
+    expect(prismaMock.familyMembership.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { userId: 9, familyId: 1 },
+      }),
+    );
+    expect(result.memberCount).toBe(2);
+  });
+
+  it('rejects duplicate family joins', async () => {
+    prismaMock.family.findUnique = jest.fn().mockResolvedValue({
+      id: 1,
+      name: 'Smith Family',
+      joinCode: 'ABCD1234',
+      creatorId: 7,
+      memberships: [
+        {
+          userId: 9,
+          user: { id: 9, name: 'Bob', email: 'bob@example.com' },
+        },
+      ],
+    });
+
+    await expect(
+      service.joinFamily(9, { joinCode: 'ABCD1234' }),
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('rejects unknown family join codes', async () => {
+    prismaMock.family.findUnique = jest.fn().mockResolvedValue(null);
+
+    await expect(
+      service.joinFamily(9, { joinCode: 'MISSING' }),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('requires a shared family for cross-user wishlist reads', async () => {
+    prismaMock.familyMembership.findFirst = jest.fn().mockResolvedValue(null);
+
+    await expect(service.assertSharedFamily(7, 9)).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+  });
+});

--- a/apps/api/src/families/families.service.ts
+++ b/apps/api/src/families/families.service.ts
@@ -1,0 +1,204 @@
+import {
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { createJoinCode } from '../auth/auth.utils';
+import { CreateFamilyDto } from './dto/create-family.dto';
+import { JoinFamilyDto } from './dto/join-family.dto';
+
+@Injectable()
+export class FamiliesService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  private async generateUniqueJoinCode() {
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const joinCode = createJoinCode();
+      const existingFamily = await this.prisma.family.findUnique({
+        where: { joinCode },
+        select: { id: true },
+      });
+
+      if (!existingFamily) {
+        return joinCode;
+      }
+    }
+
+    throw new ConflictException('Unable to generate a unique join code');
+  }
+
+  async listFamilies(currentUserId: number) {
+    const memberships = await this.prisma.familyMembership.findMany({
+      where: { userId: currentUserId },
+      orderBy: { createdAt: 'asc' },
+      include: {
+        family: {
+          include: {
+            memberships: {
+              include: {
+                user: {
+                  select: {
+                    id: true,
+                    name: true,
+                    email: true,
+                  },
+                },
+              },
+              orderBy: {
+                createdAt: 'asc',
+              },
+            },
+          },
+        },
+      },
+    });
+
+    return memberships.map(({ family }) => ({
+      id: family.id,
+      name: family.name,
+      joinCode: family.joinCode,
+      creatorId: family.creatorId,
+      memberCount: family.memberships.length,
+      members: family.memberships.map((membership) => membership.user),
+      createdAt: family.createdAt,
+      updatedAt: family.updatedAt,
+    }));
+  }
+
+  async createFamily(currentUserId: number, dto: CreateFamilyDto) {
+    const joinCode = await this.generateUniqueJoinCode();
+
+    const family = await this.prisma.family.create({
+      data: {
+        name: dto.name.trim(),
+        joinCode,
+        creatorId: currentUserId,
+        memberships: {
+          create: {
+            userId: currentUserId,
+          },
+        },
+      },
+      include: {
+        memberships: {
+          include: {
+            user: {
+              select: {
+                id: true,
+                name: true,
+                email: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    return {
+      id: family.id,
+      name: family.name,
+      joinCode: family.joinCode,
+      creatorId: family.creatorId,
+      memberCount: family.memberships.length,
+      members: family.memberships.map((membership) => membership.user),
+      createdAt: family.createdAt,
+      updatedAt: family.updatedAt,
+    };
+  }
+
+  async joinFamily(currentUserId: number, dto: JoinFamilyDto) {
+    const joinCode = dto.joinCode.trim().toUpperCase();
+    const family = await this.prisma.family.findUnique({
+      where: { joinCode },
+      include: {
+        memberships: {
+          include: {
+            user: {
+              select: {
+                id: true,
+                name: true,
+                email: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!family) {
+      throw new NotFoundException('Family not found');
+    }
+
+    const existingMembership = family.memberships.find(
+      (membership) => membership.userId === currentUserId,
+    );
+    if (existingMembership) {
+      throw new ConflictException('You are already a member of this family');
+    }
+
+    const membership = await this.prisma.familyMembership.create({
+      data: {
+        userId: currentUserId,
+        familyId: family.id,
+      },
+      include: {
+        family: {
+          include: {
+            memberships: {
+              include: {
+                user: {
+                  select: {
+                    id: true,
+                    name: true,
+                    email: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    return {
+      id: membership.family.id,
+      name: membership.family.name,
+      joinCode: membership.family.joinCode,
+      creatorId: membership.family.creatorId,
+      memberCount: membership.family.memberships.length,
+      members: membership.family.memberships.map(
+        (familyMembership) => familyMembership.user,
+      ),
+      createdAt: membership.family.createdAt,
+      updatedAt: membership.family.updatedAt,
+    };
+  }
+
+  async assertSharedFamily(currentUserId: number, ownerId: number) {
+    if (currentUserId === ownerId) {
+      return;
+    }
+
+    const sharedMembership = await this.prisma.familyMembership.findFirst({
+      where: {
+        userId: currentUserId,
+        family: {
+          memberships: {
+            some: {
+              userId: ownerId,
+            },
+          },
+        },
+      },
+      select: { id: true },
+    });
+
+    if (!sharedMembership) {
+      throw new ForbiddenException(
+        'You can only view wishlists for members of your families',
+      );
+    }
+  }
+}

--- a/apps/api/src/wishlist-items/wishlist-items.controller.spec.ts
+++ b/apps/api/src/wishlist-items/wishlist-items.controller.spec.ts
@@ -41,4 +41,25 @@ describe('WishlistItemsController', () => {
     expect(serviceMock.deleteWishlistItem).toHaveBeenCalledWith(42, 7);
     expect(result).toBeUndefined();
   });
+
+  it('passes the authenticated user to wishlist reads', async () => {
+    serviceMock.getWishlistItems = jest.fn().mockResolvedValue({
+      data: [],
+      meta: {
+        page: 1,
+        limit: 10,
+        total: 0,
+        totalPages: 0,
+      },
+    });
+
+    await controller.getWishlistItems(
+      { id: 7, name: 'Alice', email: 'alice@example.com' },
+      '1',
+      '10',
+      '9',
+    );
+
+    expect(serviceMock.getWishlistItems).toHaveBeenCalledWith(7, 1, 10, 9);
+  });
 });

--- a/apps/api/src/wishlist-items/wishlist-items.controller.ts
+++ b/apps/api/src/wishlist-items/wishlist-items.controller.ts
@@ -22,6 +22,7 @@ export class WishlistItemsController {
   /// `api/wishlist-items/` if i put something in @Get it adds that to make it `/api/wishlist-items/wishlist/items
   @Get()
   getWishlistItems(
+    @CurrentUser() user: AuthenticatedUser,
     @Query('page') page?: string,
     @Query('limit') limit?: string,
     @Query('userId') userId?: string,
@@ -39,6 +40,7 @@ export class WishlistItemsController {
     }
 
     return this.wishlistItemsService.getWishlistItems(
+      user.id,
       pageNum,
       limitNum,
       userIdNum,

--- a/apps/api/src/wishlist-items/wishlist-items.module.ts
+++ b/apps/api/src/wishlist-items/wishlist-items.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
+import { FamiliesModule } from '../families/families.module';
 import { WishlistItemsController } from './wishlist-items.controller';
 import { WishlistItemsService } from './wishlist-items.service';
 
 @Module({
+  imports: [FamiliesModule],
   controllers: [WishlistItemsController],
   providers: [WishlistItemsService],
 })

--- a/apps/api/src/wishlist-items/wishlist-items.service.spec.ts
+++ b/apps/api/src/wishlist-items/wishlist-items.service.spec.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/unbound-method */
-import { NotFoundException } from '@nestjs/common';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { Test, TestingModule } from '@nestjs/testing';
+import { FamiliesService } from '../families/families.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { WishlistItemsService } from './wishlist-items.service';
 
@@ -15,12 +16,16 @@ describe('WishlistItemsService', () => {
       delete: jest.fn(),
     },
   } as unknown as PrismaService;
+  const familiesServiceMock = {
+    assertSharedFamily: jest.fn(),
+  } as unknown as FamiliesService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         WishlistItemsService,
         { provide: PrismaService, useValue: prismaMock },
+        { provide: FamiliesService, useValue: familiesServiceMock },
       ],
     }).compile();
 
@@ -53,17 +58,69 @@ describe('WishlistItemsService', () => {
     prismaMock.wishlistItem.findMany = jest.fn().mockResolvedValue(sampleItems);
     prismaMock.wishlistItem.count = jest.fn().mockResolvedValue(12);
 
-    const result = await service.getWishlistItems(2, 5);
+    const result = await service.getWishlistItems(7, 2, 5);
 
     expect(prismaMock.wishlistItem.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: {},
+        where: {
+          OR: [
+            { wishlist: { is: { userId: 7 } } },
+            {
+              wishlist: {
+                is: {
+                  user: {
+                    is: {
+                      memberships: {
+                        some: {
+                          family: {
+                            memberships: {
+                              some: {
+                                userId: 7,
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        },
         orderBy: { createdAt: 'desc' },
         skip: 5,
         take: 5,
       }),
     );
-    expect(prismaMock.wishlistItem.count).toHaveBeenCalledWith({ where: {} });
+    expect(prismaMock.wishlistItem.count).toHaveBeenCalledWith({
+      where: {
+        OR: [
+          { wishlist: { is: { userId: 7 } } },
+          {
+            wishlist: {
+              is: {
+                user: {
+                  is: {
+                    memberships: {
+                      some: {
+                        family: {
+                          memberships: {
+                            some: {
+                              userId: 7,
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
     expect(result).toEqual({
       data: [
         {
@@ -91,7 +148,7 @@ describe('WishlistItemsService', () => {
     prismaMock.wishlistItem.findMany = jest.fn().mockResolvedValue([]);
     prismaMock.wishlistItem.count = jest.fn().mockResolvedValue(7);
 
-    await service.getWishlistItems(1, 5);
+    await service.getWishlistItems(7, 1, 5);
 
     expect(prismaMock.wishlistItem.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -99,7 +156,7 @@ describe('WishlistItemsService', () => {
         take: 5,
       }),
     );
-    const result = await service.getWishlistItems(2, 5);
+    const result = await service.getWishlistItems(7, 2, 5);
 
     expect(result.meta.totalPages).toBe(2); // 7 items with limit 5 => ceil(7/5)=2
     expect(prismaMock.wishlistItem.findMany).toHaveBeenLastCalledWith(
@@ -113,19 +170,84 @@ describe('WishlistItemsService', () => {
   it('filters results by userId when provided', async () => {
     prismaMock.wishlistItem.findMany = jest.fn().mockResolvedValue([]);
     prismaMock.wishlistItem.count = jest.fn().mockResolvedValue(0);
+    familiesServiceMock.assertSharedFamily = jest
+      .fn()
+      .mockResolvedValue(undefined);
 
-    await service.getWishlistItems(1, 10, 42);
+    await service.getWishlistItems(7, 1, 10, 42);
 
+    expect(familiesServiceMock.assertSharedFamily).toHaveBeenCalledWith(7, 42);
     expect(prismaMock.wishlistItem.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { wishlist: { userId: 42 } },
+        where: { wishlist: { is: { userId: 42 } } },
         skip: 0,
         take: 10,
       }),
     );
     expect(prismaMock.wishlistItem.count).toHaveBeenCalledWith({
-      where: { wishlist: { userId: 42 } },
+      where: { wishlist: { is: { userId: 42 } } },
     });
+  });
+
+  it('limits general results to the current user and shared-family members', async () => {
+    prismaMock.wishlistItem.findMany = jest.fn().mockResolvedValue([]);
+    prismaMock.wishlistItem.count = jest.fn().mockResolvedValue(0);
+
+    await service.getWishlistItems(7, 1, 10);
+
+    expect(prismaMock.wishlistItem.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          OR: [
+            { wishlist: { is: { userId: 7 } } },
+            {
+              wishlist: {
+                is: {
+                  user: {
+                    is: {
+                      memberships: {
+                        some: {
+                          family: {
+                            memberships: {
+                              some: {
+                                userId: 7,
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        },
+      }),
+    );
+  });
+
+  it('does not require a shared family check for the current user', async () => {
+    prismaMock.wishlistItem.findMany = jest.fn().mockResolvedValue([]);
+    prismaMock.wishlistItem.count = jest.fn().mockResolvedValue(0);
+
+    await service.getWishlistItems(7, 1, 10, 7);
+
+    expect(familiesServiceMock.assertSharedFamily).not.toHaveBeenCalled();
+  });
+
+  it('surfaces shared-family authorization failures', async () => {
+    familiesServiceMock.assertSharedFamily = jest
+      .fn()
+      .mockRejectedValue(
+        new ForbiddenException(
+          'You can only view wishlists for members of your families',
+        ),
+      );
+
+    await expect(service.getWishlistItems(1, 1, 10, 99)).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
   });
 
   it('deletes a wishlist item successfully', async () => {

--- a/apps/api/src/wishlist-items/wishlist-items.service.ts
+++ b/apps/api/src/wishlist-items/wishlist-items.service.ts
@@ -4,13 +4,22 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
+import { FamiliesService } from '../families/families.service';
 import { PrismaService } from '../prisma/prisma.service';
 
 @Injectable()
 export class WishlistItemsService {
-  constructor(private prisma: PrismaService) {}
+  constructor(
+    private prisma: PrismaService,
+    private readonly familiesService: FamiliesService,
+  ) {}
 
-  async getWishlistItems(page: number, limit: number, userId?: number) {
+  async getWishlistItems(
+    currentUserId: number,
+    page: number,
+    limit: number,
+    userId?: number,
+  ) {
     // need to include queries here and they are numbers because the controller transformed it
     const skip = (page - 1) * limit;
     // implementing offset Pagination using limit and offset.  Skip maps to offset and takes maps to Limit
@@ -19,7 +28,38 @@ export class WishlistItemsService {
     // OFFSET 10;
     // Page 1 = entries 1 - 5 => limit 5 offset 0
     // Page 2 = 6 - 10 => limit 5 offset 5 (skip first 5)
-    const where = userId ? { wishlist: { userId } } : {};
+    if (userId && userId !== currentUserId) {
+      await this.familiesService.assertSharedFamily(currentUserId, userId);
+    }
+
+    const where: Prisma.WishlistItemWhereInput = userId
+      ? { wishlist: { is: { userId } } }
+      : {
+          OR: [
+            { wishlist: { is: { userId: currentUserId } } },
+            {
+              wishlist: {
+                is: {
+                  user: {
+                    is: {
+                      memberships: {
+                        some: {
+                          family: {
+                            memberships: {
+                              some: {
+                                userId: currentUserId,
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        };
     const [data, total] = await Promise.all([
       this.prisma.wishlistItem.findMany({
         where,

--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -8,7 +8,7 @@
 
 .app-shell {
   margin: 0 auto;
-  max-width: 960px;
+  max-width: 1200px;
 }
 
 .auth-shell {
@@ -24,6 +24,27 @@
   background: rgba(255, 255, 255, 0.92);
   box-shadow: 0 24px 60px rgba(15, 23, 42, 0.18);
   color: #1f2937;
+}
+
+.content-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.panel {
+  border-radius: 24px;
+  padding: 1.5rem;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.12);
+  color: #1f2937;
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+  margin-bottom: 1rem;
 }
 
 .app-header {
@@ -54,6 +75,12 @@
   margin: 1.5rem 0 1rem;
 }
 
+.auth-links {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
 .auth-form input {
   width: 100%;
   box-sizing: border-box;
@@ -63,9 +90,32 @@
   font-size: 1rem;
 }
 
+.stacked-form input,
+.stacked-form button,
+.auth-form button {
+  width: 100%;
+}
+
+.stacked-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.stacked-form label {
+  font-weight: 600;
+}
+
+.family-forms {
+  display: grid;
+  gap: 1rem;
+  margin: 1rem 0;
+}
+
 .primary-action {
   background: #2563eb;
   color: #fff;
+  border: none;
 }
 
 .secondary-action {
@@ -74,7 +124,83 @@
   color: #1f2937;
 }
 
+.primary-action,
+.secondary-action {
+  border-radius: 12px;
+  padding: 0.85rem 1rem;
+  cursor: pointer;
+  font-size: 0.95rem;
+}
+
 .form-error {
   margin: 0;
   color: #b91c1c;
+}
+
+.form-notice {
+  margin: 0;
+  color: #166534;
+}
+
+.info-panel,
+.empty-state,
+.family-card {
+  border-radius: 18px;
+  border: 1px solid #dbeafe;
+  background: #eff6ff;
+  padding: 1rem;
+}
+
+.family-list,
+.wishlist-stack {
+  display: grid;
+  gap: 1rem;
+}
+
+.family-card-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+}
+
+.family-members {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.family-members li {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+}
+
+.family-members span {
+  color: #64748b;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  background: #dbeafe;
+  color: #1d4ed8;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+@media (min-width: 960px) {
+  .content-grid {
+    grid-template-columns: minmax(320px, 380px) minmax(0, 1fr);
+    align-items: start;
+  }
+
+  .family-forms {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,23 +1,38 @@
 import { useCallback, useEffect, useState } from 'react';
 import type { FormEvent } from 'react';
 import './App.css';
-import { getCurrentUser, login, logout, register } from './api/auth';
+import { forgotPassword, getCurrentUser, login, logout, register, resetPassword } from './api/auth';
+import { createFamily, getFamilies, joinFamily } from './api/families';
 import { deleteWishListItem, getWishlistItems } from './api/wishlistItems';
 import { Card, DropDown, PaginationButtons, UserSearch } from './components/index';
-import type { AuthUser, PaginationMeta, WishlistItemResponse } from './types/wishlist';
+import type {
+  AuthUser,
+  FamilySummary,
+  PaginationMeta,
+  WishlistItemResponse,
+} from './types/wishlist';
 
 const DEFAULT_LIMIT = 10;
 
+type AuthMode = 'login' | 'register' | 'forgot' | 'reset';
+
 function App() {
-  const [authMode, setAuthMode] = useState<'login' | 'register'>('login');
+  const [authMode, setAuthMode] = useState<AuthMode>('login');
   const [currentUser, setCurrentUser] = useState<AuthUser | null>(null);
   const [authLoading, setAuthLoading] = useState(true);
   const [authError, setAuthError] = useState<string | null>(null);
+  const [authNotice, setAuthNotice] = useState<string | null>(null);
   const [authForm, setAuthForm] = useState({
     name: '',
     email: '',
     password: '',
+    resetToken: '',
+    newPassword: '',
   });
+  const [devResetToken, setDevResetToken] = useState<{
+    token: string;
+    expiresAt?: string;
+  } | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [wishlistItems, setWishlistItems] = useState<WishlistItemResponse[]>([]);
@@ -26,6 +41,14 @@ function App() {
   const [currentPage, setCurrentPage] = useState(1);
   const [meta, setMeta] = useState<PaginationMeta>();
   const [limit, setLimit] = useState(DEFAULT_LIMIT);
+  const [families, setFamilies] = useState<FamilySummary[]>([]);
+  const [familyLoading, setFamilyLoading] = useState(false);
+  const [familyError, setFamilyError] = useState<string | null>(null);
+  const [familyNotice, setFamilyNotice] = useState<string | null>(null);
+  const [familyForm, setFamilyForm] = useState({
+    createName: '',
+    joinCode: '',
+  });
 
   const bootstrapUser = useCallback(async () => {
     setAuthLoading(true);
@@ -40,6 +63,24 @@ function App() {
     }
   }, []);
 
+  const fetchFamilies = useCallback(async () => {
+    if (!currentUser) {
+      setFamilies([]);
+      return;
+    }
+
+    setFamilyLoading(true);
+    try {
+      const response = await getFamilies();
+      setFamilies(response);
+      setFamilyError(null);
+    } catch (err) {
+      setFamilyError(err instanceof Error ? err.message : 'Failed to load families');
+    } finally {
+      setFamilyLoading(false);
+    }
+  }, [currentUser]);
+
   const fetchData = useCallback(async () => {
     if (!currentUser) {
       return;
@@ -52,7 +93,8 @@ function App() {
       setWishlistItems(res.data);
       setMeta(res.meta);
     } catch (err) {
-      console.error(err);
+      setWishlistItems([]);
+      setMeta(undefined);
       setError(err instanceof Error ? err.message : 'Failed to load wishlist items');
     } finally {
       setLoading(false);
@@ -64,10 +106,13 @@ function App() {
   }, [bootstrapUser]);
 
   useEffect(() => {
-    if (currentUser) {
-      void fetchData();
+    if (!currentUser) {
+      return;
     }
-  }, [currentUser, fetchData]);
+
+    void fetchData();
+    void fetchFamilies();
+  }, [currentUser, fetchData, fetchFamilies]);
 
   const handleBackPage = () => {
     setCurrentPage((page) => Math.max(1, page - 1));
@@ -101,9 +146,22 @@ function App() {
         item.wishlistTitle.toLowerCase().includes(searchUserName.toLowerCase()),
   );
 
+  const resetAuthFeedback = () => {
+    setAuthError(null);
+    setAuthNotice(null);
+  };
+
+  const handleAuthModeChange = (mode: AuthMode) => {
+    resetAuthFeedback();
+    if (mode !== 'reset') {
+      setDevResetToken(null);
+    }
+    setAuthMode(mode);
+  };
+
   const handleAuthSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    setAuthError(null);
+    resetAuthFeedback();
 
     try {
       const normalizedEmail = authForm.email.trim().toLowerCase();
@@ -114,17 +172,73 @@ function App() {
           email: normalizedEmail,
           password: authForm.password,
         });
+
+        const response = await login({
+          email: normalizedEmail,
+          password: authForm.password,
+        });
+
+        setCurrentUser(response.user);
+        setAuthForm({
+          name: '',
+          email: '',
+          password: '',
+          resetToken: '',
+          newPassword: '',
+        });
+        setCurrentPage(1);
+        setError(null);
+        return;
       }
 
-      const response = await login({
-        email: normalizedEmail,
-        password: authForm.password,
-      });
+      if (authMode === 'login') {
+        const response = await login({
+          email: normalizedEmail,
+          password: authForm.password,
+        });
 
-      setCurrentUser(response.user);
-      setAuthForm({ name: '', email: '', password: '' });
-      setCurrentPage(1);
-      setError(null);
+        setCurrentUser(response.user);
+        setAuthForm({
+          name: '',
+          email: '',
+          password: '',
+          resetToken: '',
+          newPassword: '',
+        });
+        setCurrentPage(1);
+        setError(null);
+        return;
+      }
+
+      if (authMode === 'forgot') {
+        const response = await forgotPassword(normalizedEmail);
+        setAuthNotice(response.message);
+        if (response.resetToken) {
+          setDevResetToken({
+            token: response.resetToken,
+            expiresAt: response.expiresAt,
+          });
+          setAuthForm((current) => ({
+            ...current,
+            resetToken: response.resetToken ?? '',
+          }));
+        }
+        return;
+      }
+
+      const response = await resetPassword({
+        token: authForm.resetToken.trim(),
+        password: authForm.newPassword,
+      });
+      setAuthNotice(response.message);
+      setAuthForm((current) => ({
+        ...current,
+        password: '',
+        resetToken: '',
+        newPassword: '',
+      }));
+      setDevResetToken(null);
+      setAuthMode('login');
     } catch (err) {
       setAuthError(err instanceof Error ? err.message : 'Unable to authenticate right now');
     }
@@ -137,8 +251,44 @@ function App() {
       setCurrentUser(null);
       setWishlistItems([]);
       setMeta(undefined);
+      setFamilies([]);
       setError(null);
       setAuthError(null);
+      setAuthNotice(null);
+      setFamilyError(null);
+      setFamilyNotice(null);
+    }
+  };
+
+  const handleCreateFamily = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setFamilyError(null);
+    setFamilyNotice(null);
+
+    try {
+      const family = await createFamily(familyForm.createName.trim());
+      setFamilies((current) => [...current, family]);
+      setFamilyForm((current) => ({ ...current, createName: '' }));
+      setFamilyNotice(`Created ${family.name}. Share code ${family.joinCode} with relatives.`);
+      await fetchData();
+    } catch (err) {
+      setFamilyError(err instanceof Error ? err.message : 'Failed to create family');
+    }
+  };
+
+  const handleJoinFamily = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setFamilyError(null);
+    setFamilyNotice(null);
+
+    try {
+      const family = await joinFamily(familyForm.joinCode.trim());
+      setFamilies((current) => [...current, family]);
+      setFamilyForm((current) => ({ ...current, joinCode: '' }));
+      setFamilyNotice(`Joined ${family.name}. You can now view shared family wishlists.`);
+      await fetchData();
+    } catch (err) {
+      setFamilyError(err instanceof Error ? err.message : 'Failed to join family');
     }
   };
 
@@ -147,19 +297,35 @@ function App() {
   }
 
   if (!currentUser) {
+    const showPasswordField = authMode === 'login' || authMode === 'register';
+    const showNameField = authMode === 'register';
+    const showForgotField = authMode === 'forgot';
+    const showResetFields = authMode === 'reset';
+
     return (
       <div className="auth-shell">
         <div className="auth-card">
           <p className="eyebrow">Wishlist</p>
-          <h1>{authMode === 'login' ? 'Sign in' : 'Create account'}</h1>
-          <p className="subtle">Sign in to browse wishlists and manage your own items.</p>
+          <h1>
+            {authMode === 'login' && 'Sign in'}
+            {authMode === 'register' && 'Create account'}
+            {authMode === 'forgot' && 'Forgot password'}
+            {authMode === 'reset' && 'Reset password'}
+          </h1>
+          <p className="subtle">
+            {authMode === 'login' &&
+              'Sign in to browse family wishlists and manage your own items.'}
+            {authMode === 'register' && 'Create an account, then sign in immediately.'}
+            {authMode === 'forgot' && 'Request a short-lived reset token for your account.'}
+            {authMode === 'reset' && 'Use your reset token to choose a new password.'}
+          </p>
           <form
             className="auth-form"
             onSubmit={(event) => {
               void handleAuthSubmit(event);
             }}
           >
-            {authMode === 'register' && (
+            {showNameField && (
               <input
                 type="text"
                 placeholder="Name"
@@ -172,41 +338,104 @@ function App() {
                 }
               />
             )}
-            <input
-              type="email"
-              placeholder="Email"
-              value={authForm.email}
-              onChange={(event) =>
-                setAuthForm((current) => ({
-                  ...current,
-                  email: event.target.value,
-                }))
-              }
-            />
-            <input
-              type="password"
-              placeholder="Password"
-              value={authForm.password}
-              onChange={(event) =>
-                setAuthForm((current) => ({
-                  ...current,
-                  password: event.target.value,
-                }))
-              }
-            />
+            {(showPasswordField || showForgotField) && (
+              <input
+                type="email"
+                placeholder="Email"
+                value={authForm.email}
+                onChange={(event) =>
+                  setAuthForm((current) => ({
+                    ...current,
+                    email: event.target.value,
+                  }))
+                }
+              />
+            )}
+            {showPasswordField && (
+              <input
+                type="password"
+                placeholder="Password"
+                value={authForm.password}
+                onChange={(event) =>
+                  setAuthForm((current) => ({
+                    ...current,
+                    password: event.target.value,
+                  }))
+                }
+              />
+            )}
+            {showResetFields && (
+              <>
+                <input
+                  type="text"
+                  placeholder="Reset token"
+                  value={authForm.resetToken}
+                  onChange={(event) =>
+                    setAuthForm((current) => ({
+                      ...current,
+                      resetToken: event.target.value,
+                    }))
+                  }
+                />
+                <input
+                  type="password"
+                  placeholder="New password"
+                  value={authForm.newPassword}
+                  onChange={(event) =>
+                    setAuthForm((current) => ({
+                      ...current,
+                      newPassword: event.target.value,
+                    }))
+                  }
+                />
+              </>
+            )}
             {authError && <p className="form-error">{authError}</p>}
+            {authNotice && <p className="form-notice">{authNotice}</p>}
+            {devResetToken && (
+              <div className="info-panel">
+                <strong>Development reset token</strong>
+                <p>{devResetToken.token}</p>
+                {devResetToken.expiresAt && <p>Expires: {devResetToken.expiresAt}</p>}
+              </div>
+            )}
             <button type="submit" className="primary-action">
-              {authMode === 'login' ? 'Sign in' : 'Register and sign in'}
+              {authMode === 'login' && 'Sign in'}
+              {authMode === 'register' && 'Register and sign in'}
+              {authMode === 'forgot' && 'Generate reset token'}
+              {authMode === 'reset' && 'Update password'}
             </button>
           </form>
-          <button
-            className="secondary-action"
-            onClick={() => setAuthMode((current) => (current === 'login' ? 'register' : 'login'))}
-          >
-            {authMode === 'login'
-              ? 'Need an account? Register'
-              : 'Already have an account? Sign in'}
-          </button>
+          <div className="auth-links">
+            {authMode !== 'login' && (
+              <button className="secondary-action" onClick={() => handleAuthModeChange('login')}>
+                Back to sign in
+              </button>
+            )}
+            {authMode === 'login' && (
+              <>
+                <button
+                  className="secondary-action"
+                  onClick={() => handleAuthModeChange('register')}
+                >
+                  Need an account? Register
+                </button>
+                <button className="secondary-action" onClick={() => handleAuthModeChange('forgot')}>
+                  Forgot password?
+                </button>
+              </>
+            )}
+            {authMode === 'forgot' && (
+              <button className="secondary-action" onClick={() => handleAuthModeChange('reset')}>
+                Already have a token? Reset password
+              </button>
+            )}
+            {authMode === 'reset' && (
+              <button className="secondary-action" onClick={() => handleAuthModeChange('forgot')}>
+                Need a token first?
+              </button>
+            )}
+          </div>
         </div>
       </div>
     );
@@ -224,48 +453,150 @@ function App() {
           Sign out
         </button>
       </div>
-      {loading && <h2>Loading...</h2>}
-      {error ? (
-        <div>
-          <h2>{error}</h2>
-        </div>
-      ) : (
-        <div className="flex flex-col items-center">
+
+      <div className="content-grid">
+        <section className="panel">
+          <div className="panel-header">
+            <div>
+              <h2>Your families</h2>
+              <p className="subtle">
+                Wishlist visibility is limited to people who share at least one family with you.
+              </p>
+            </div>
+            {familyLoading && <span className="pill">Refreshing</span>}
+          </div>
+          <div className="family-forms">
+            <form className="stacked-form" onSubmit={(event) => void handleCreateFamily(event)}>
+              <label htmlFor="create-family-name">Create family</label>
+              <input
+                id="create-family-name"
+                type="text"
+                placeholder="Family name"
+                value={familyForm.createName}
+                onChange={(event) =>
+                  setFamilyForm((current) => ({
+                    ...current,
+                    createName: event.target.value,
+                  }))
+                }
+              />
+              <button type="submit" className="primary-action">
+                Create family
+              </button>
+            </form>
+            <form className="stacked-form" onSubmit={(event) => void handleJoinFamily(event)}>
+              <label htmlFor="join-family-code">Join family</label>
+              <input
+                id="join-family-code"
+                type="text"
+                placeholder="Invite code"
+                value={familyForm.joinCode}
+                onChange={(event) =>
+                  setFamilyForm((current) => ({
+                    ...current,
+                    joinCode: event.target.value.toUpperCase(),
+                  }))
+                }
+              />
+              <button type="submit" className="secondary-action">
+                Join with code
+              </button>
+            </form>
+          </div>
+          {familyError && <p className="form-error">{familyError}</p>}
+          {familyNotice && <p className="form-notice">{familyNotice}</p>}
+          <div className="family-list">
+            {families.length === 0 ? (
+              <div className="empty-state">
+                <h3>No families yet</h3>
+                <p>Create one or join one to see other people’s wishlists.</p>
+              </div>
+            ) : (
+              families.map((family) => (
+                <article className="family-card" key={family.id}>
+                  <div className="family-card-header">
+                    <div>
+                      <h3>{family.name}</h3>
+                      <p className="subtle">Invite code: {family.joinCode}</p>
+                    </div>
+                    <span className="pill">{family.memberCount} members</span>
+                  </div>
+                  <ul className="family-members">
+                    {family.members.map((member) => (
+                      <li key={member.id}>
+                        <strong>{member.name}</strong>
+                        <span>{member.email}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </article>
+              ))
+            )}
+          </div>
+        </section>
+
+        <section className="panel">
+          <div className="panel-header">
+            <div>
+              <h2>Shared wishlist feed</h2>
+              <p className="subtle">
+                The feed shows your own items plus wishlists from users who share a family with you.
+              </p>
+            </div>
+          </div>
           <UserSearch
             onSubmit={handleSearchSubmit}
             value={inputUserName}
             onChange={setInputUserName}
           />
-          <div className="w-full max-w-md space-y-6">
-            {filteredItems.map((item) => (
-              <Card
-                {...item}
-                key={item.id}
-                onDelete={(id) => {
-                  if (item.ownerId !== currentUser.id) {
-                    setError('You can only delete items from your own wishlist.');
-                    return;
-                  }
+          {loading && <h2>Loading...</h2>}
+          {error ? (
+            <div className="empty-state">
+              <h3>{error}</h3>
+            </div>
+          ) : filteredItems.length === 0 ? (
+            <div className="empty-state">
+              <h3>No visible wishlist items</h3>
+              <p>
+                {families.length === 0
+                  ? 'You can only see your own items until you create or join a family.'
+                  : 'No items match your current family access and search filters.'}
+              </p>
+            </div>
+          ) : (
+            <>
+              <div className="wishlist-stack">
+                {filteredItems.map((item) => (
+                  <Card
+                    {...item}
+                    key={item.id}
+                    onDelete={(id) => {
+                      if (item.ownerId !== currentUser.id) {
+                        setError('You can only delete items from your own wishlist.');
+                        return;
+                      }
 
-                  void onDeleteItem(id);
-                }}
+                      void onDeleteItem(id);
+                    }}
+                  />
+                ))}
+              </div>
+              <PaginationButtons
+                handleBackPage={handleBackPage}
+                handleNextPage={handleNextPage}
+                currentPage={currentPage}
+                totalPages={meta?.totalPages}
               />
-            ))}
-          </div>
-          <PaginationButtons
-            handleBackPage={handleBackPage}
-            handleNextPage={handleNextPage}
-            currentPage={currentPage}
-            totalPages={meta?.totalPages}
-          />
-          <DropDown
-            limit={limit}
-            setLimit={setLimit}
-            setCurrentPage={setCurrentPage}
-            totalItems={meta?.total}
-          />
-        </div>
-      )}
+              <DropDown
+                limit={limit}
+                setLimit={setLimit}
+                setCurrentPage={setCurrentPage}
+                totalItems={meta?.total}
+              />
+            </>
+          )}
+        </section>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/api/auth.ts
+++ b/apps/web/src/api/auth.ts
@@ -8,7 +8,7 @@ type AuthPayload = {
   name?: string;
 };
 
-async function apiRequest<T>(path: string, init?: RequestInit) {
+export async function apiRequest<T>(path: string, init?: RequestInit) {
   const response = await fetch(`${BASE_URL}${path}`, {
     credentials: 'include',
     headers: {
@@ -59,3 +59,27 @@ export function logout() {
 type AuthResponse = {
   user: AuthUser;
 };
+
+export type ForgotPasswordResponse = {
+  message: string;
+  resetToken?: string;
+  expiresAt?: string;
+};
+
+export type ResetPasswordResponse = {
+  message: string;
+};
+
+export function forgotPassword(email: string) {
+  return apiRequest<ForgotPasswordResponse>('/api/auth/forgot-password', {
+    method: 'POST',
+    body: JSON.stringify({ email }),
+  });
+}
+
+export function resetPassword(payload: { token: string; password: string }) {
+  return apiRequest<ResetPasswordResponse>('/api/auth/reset-password', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}

--- a/apps/web/src/api/families.ts
+++ b/apps/web/src/api/families.ts
@@ -1,0 +1,20 @@
+import type { FamilySummary } from '../types/wishlist';
+import { apiRequest } from './auth';
+
+export function getFamilies() {
+  return apiRequest<FamilySummary[]>('/api/families');
+}
+
+export function createFamily(name: string) {
+  return apiRequest<FamilySummary>('/api/families', {
+    method: 'POST',
+    body: JSON.stringify({ name }),
+  });
+}
+
+export function joinFamily(joinCode: string) {
+  return apiRequest<FamilySummary>('/api/families/join', {
+    method: 'POST',
+    body: JSON.stringify({ joinCode }),
+  });
+}

--- a/apps/web/src/api/wishlistItems.tsx
+++ b/apps/web/src/api/wishlistItems.tsx
@@ -21,7 +21,11 @@ export async function getWishlistItems(
   });
 
   if (!response.ok) {
-    throw new Error('Failed to fetch wishlist items');
+    const data = (await response.json().catch(() => null)) as {
+      message?: string;
+      error?: string;
+    } | null;
+    throw new Error(data?.message ?? data?.error ?? 'Failed to fetch wishlist items');
   }
   return response.json() as Promise<PaginatedWishlistItems>;
 }
@@ -33,6 +37,10 @@ export async function deleteWishListItem(itemId: number) {
   });
 
   if (!response.ok) {
-    throw new Error(`Failed to delete itemId: ${itemId}`);
+    const data = (await response.json().catch(() => null)) as {
+      message?: string;
+      error?: string;
+    } | null;
+    throw new Error(data?.message ?? data?.error ?? `Failed to delete itemId: ${itemId}`);
   }
 }

--- a/apps/web/src/types/wishlist.tsx
+++ b/apps/web/src/types/wishlist.tsx
@@ -12,6 +12,23 @@ export interface AuthUser {
   name: string;
 }
 
+export interface FamilyMember {
+  id: number;
+  email: string;
+  name: string;
+}
+
+export interface FamilySummary {
+  id: number;
+  name: string;
+  joinCode: string;
+  creatorId: number;
+  memberCount: number;
+  members: FamilyMember[];
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface CardProps extends WishlistItemResponse {
   onDelete: (id: number) => void;
 }

--- a/docs/plans/milestone-6-password-reset-and-family-memberships.md
+++ b/docs/plans/milestone-6-password-reset-and-family-memberships.md
@@ -1,0 +1,100 @@
+# Milestone 6: Password Reset and Family Memberships
+
+## Summary
+
+Finish the last two open issues in milestone 6 by adding a token-based password reset flow and family memberships that gate wishlist visibility. This work extends the existing Nest API and React web app without changing the session-based authentication foundation already merged.
+
+Password reset is implemented without email delivery in this milestone. Family memberships are multi-family, users join by invite code, and wishlist reads are restricted to people who share at least one family.
+
+## Implementation Plan
+
+### API and Data Model
+
+- Add a `PasswordResetToken` table tied to `User`.
+- Store only a hashed reset token, expiry timestamp, created timestamp, and optional `usedAt`.
+- Add `Family` and `FamilyMembership` tables.
+- Keep users multi-family capable through a join table rather than a single `familyId`.
+- Add uniqueness so the same user cannot join the same family twice.
+
+### Auth and Authorization
+
+- Add `POST /api/auth/forgot-password`.
+- Add `POST /api/auth/reset-password`.
+- Forgot-password always returns a generic success message, even for unknown emails.
+- In non-production environments, the reset token is returned in the response so the flow is testable without email.
+- Reset-password validates token expiry and one-time use, updates the password hash, invalidates active sessions, and marks the token used.
+- Add family endpoints:
+  - `GET /api/families`
+  - `POST /api/families`
+  - `POST /api/families/join`
+- Change wishlist read authorization from “any authenticated user” to “authenticated user sharing at least one family with the wishlist owner.”
+- Keep wishlist mutation rules owner-only.
+
+### Web App
+
+- Add forgot-password and reset-password forms to the auth flow.
+- Surface development reset tokens in the UI when returned by the API.
+- Add a family management panel that supports:
+  - creating a family
+  - joining a family by invite code
+  - listing current memberships and join codes
+- Update the shared wishlist feed copy so it explains that visibility is family-based.
+
+## Public API and Data Model Changes
+
+### Auth Endpoints
+
+- `POST /api/auth/forgot-password`
+  - Request: `{ email: string }`
+  - Response: generic success payload
+  - Development-only response may include `resetToken` and `expiresAt`
+- `POST /api/auth/reset-password`
+  - Request: `{ token: string, password: string }`
+  - Response: success message
+
+### Family Endpoints
+
+- `GET /api/families`
+  - Response: all families for the current user
+- `POST /api/families`
+  - Request: `{ name: string }`
+  - Response: created family including generated join code
+- `POST /api/families/join`
+  - Request: `{ joinCode: string }`
+  - Response: joined family summary
+
+### Prisma Models
+
+- `PasswordResetToken`
+- `Family`
+- `FamilyMembership`
+
+## Test Plan
+
+- Forgot-password returns success for both known and unknown emails.
+- Reset-password accepts a valid token, updates the password, and invalidates prior sessions.
+- Expired or invalid reset tokens are rejected.
+- Creating a family adds the creator as a member.
+- Joining by invite code adds a membership and rejects duplicates safely.
+- Users can belong to multiple families.
+- Wishlist reads fail with `403` when users do not share a family.
+- Wishlist reads succeed when users share at least one family.
+- Owner-only wishlist mutation behavior remains unchanged.
+
+## Assumptions
+
+- Real email delivery is out of scope for this milestone.
+- Users can belong to more than one family.
+- Joining a family is self-service through a join code, not an approval flow.
+- Shared-family access applies to wishlist reads only; edits remain owner-only.
+
+## How It Works
+
+- A signed-out user can request a password reset token by email.
+- If the account exists, the API creates a short-lived reset token and stores only its hash.
+- In development, the raw reset token is returned so the reset flow can be completed without email infrastructure.
+- Resetting the password consumes the token, updates the stored password hash, and invalidates existing sessions.
+- A signed-in user can create a family, which generates a reusable join code and automatically adds the creator as a member.
+- A signed-in user can join additional families by entering a valid invite code.
+- The shared wishlist feed shows a user’s own items plus items owned by users who share at least one family membership.
+- Users still cannot create or delete wishlist items on behalf of other users.


### PR DESCRIPTION
## Summary
- add token-based password reset endpoints and tests
- add family create/join/list endpoints plus shared-family wishlist visibility
- add the React UI for reset and family management and save the implementation plan under docs/plans

## Verification
- DATABASE_URL="file:./prisma/dev.db" npx prisma generate --schema prisma/schema.prisma
- DATABASE_URL="file:./prisma/dev.db" npx prisma migrate deploy --schema prisma/schema.prisma
- npm test -- --runInBand -w apps/api
- npm run build -w apps/api
- npm run build -w apps/web
- npx eslint apps/api/src/**/*.ts apps/web/src/**/*.tsx apps/web/src/**/*.ts

Closes #41
Closes #55