### PR TITLE
Add family roles and invite links

### DIFF
--- a/apps/api/prisma/migrations/20260326010000_add_family_roles_and_invites/migration.sql
+++ b/apps/api/prisma/migrations/20260326010000_add_family_roles_and_invites/migration.sql
@@ -1,0 +1,41 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_FamilyMembership" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "userId" INTEGER NOT NULL,
+    "familyId" INTEGER NOT NULL,
+    "role" TEXT NOT NULL DEFAULT 'member',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "FamilyMembership_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "FamilyMembership_familyId_fkey" FOREIGN KEY ("familyId") REFERENCES "Family" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_FamilyMembership" ("createdAt", "familyId", "id", "userId")
+SELECT "createdAt", "familyId", "id", "userId" FROM "FamilyMembership";
+DROP TABLE "FamilyMembership";
+ALTER TABLE "new_FamilyMembership" RENAME TO "FamilyMembership";
+CREATE UNIQUE INDEX "FamilyMembership_userId_familyId_key" ON "FamilyMembership"("userId", "familyId");
+
+UPDATE "FamilyMembership"
+SET "role" = 'admin'
+WHERE "userId" IN (
+  SELECT "creatorId" FROM "Family" WHERE "Family"."id" = "FamilyMembership"."familyId"
+);
+
+CREATE TABLE "FamilyInvite" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "tokenHash" TEXT NOT NULL,
+    "familyId" INTEGER NOT NULL,
+    "createdByUserId" INTEGER NOT NULL,
+    "expiresAt" DATETIME NOT NULL,
+    "usedAt" DATETIME,
+    "revokedAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "FamilyInvite_familyId_fkey" FOREIGN KEY ("familyId") REFERENCES "Family" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "FamilyInvite_createdByUserId_fkey" FOREIGN KEY ("createdByUserId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE UNIQUE INDEX "FamilyInvite_tokenHash_key" ON "FamilyInvite"("tokenHash");
+CREATE INDEX "FamilyInvite_familyId_idx" ON "FamilyInvite"("familyId");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -19,6 +19,7 @@ model User {
   passwordResetTokens PasswordResetToken[]
   memberships         FamilyMembership[]
   createdFamilies     Family[]             @relation("FamilyCreator")
+  createdFamilyInvites FamilyInvite[]      @relation("FamilyInviteCreator")
   wishlists           Wishlist[]
   createdAt           DateTime             @default(now())
   updatedAt           DateTime             @updatedAt
@@ -50,6 +51,7 @@ model Family {
   creator     User               @relation("FamilyCreator", fields: [creatorId], references: [id], onDelete: Cascade)
   creatorId   Int
   memberships FamilyMembership[]
+  invites     FamilyInvite[]
   createdAt   DateTime           @default(now())
   updatedAt   DateTime           @updatedAt
 }
@@ -60,9 +62,24 @@ model FamilyMembership {
   userId    Int
   family    Family   @relation(fields: [familyId], references: [id], onDelete: Cascade)
   familyId  Int
+  role      String   @default("member")
   createdAt DateTime @default(now())
 
   @@unique([userId, familyId])
+}
+
+model FamilyInvite {
+  id              Int      @id @default(autoincrement())
+  tokenHash       String   @unique
+  family          Family   @relation(fields: [familyId], references: [id], onDelete: Cascade)
+  familyId        Int
+  createdByUser   User     @relation("FamilyInviteCreator", fields: [createdByUserId], references: [id], onDelete: Cascade)
+  createdByUserId Int
+  expiresAt       DateTime
+  usedAt          DateTime?
+  revokedAt       DateTime?
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
 }
 
 model Wishlist {

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -56,7 +56,10 @@ async function main() {
       joinCode: 'FAMILY1',
       creatorId: user1.id,
       memberships: {
-        create: [{ userId: user1.id }, { userId: user2.id }],
+        create: [
+          { userId: user1.id, role: 'admin' },
+          { userId: user2.id, role: 'member' },
+        ],
       },
     },
   });

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -6,14 +6,10 @@ import {
   Post,
   Req,
   Res,
-  UseGuards,
 } from '@nestjs/common';
 import type { Request, Response } from 'express';
 import { AuthService } from './auth.service';
 import { AUTH_COOKIE_NAME, SESSION_DURATION_MS } from './auth.constants';
-import { CurrentUser } from './current-user.decorator';
-import { AuthGuard } from './auth.guard';
-import type { AuthenticatedUser } from './auth.types';
 import { parseCookieHeader } from './auth.utils';
 import { ForgotPasswordDto } from './dto/forgot-password.dto';
 import { LoginDto } from './dto/login.dto';
@@ -77,8 +73,9 @@ export class AuthController {
   }
 
   @Get('me')
-  @UseGuards(AuthGuard)
-  getMe(@CurrentUser() user: AuthenticatedUser) {
+  async getMe(@Req() request: Request) {
+    const token = parseCookieHeader(request.headers.cookie)[AUTH_COOKIE_NAME];
+    const user = await this.authService.getCurrentUser(token);
     return { user };
   }
 }

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -53,6 +53,27 @@ describe('AuthService', () => {
     expect(prismaMock.passwordResetToken.create).not.toHaveBeenCalled();
   });
 
+  it('returns null for current user when there is no session token', async () => {
+    await expect(service.getCurrentUser()).resolves.toBeNull();
+  });
+
+  it('returns the authenticated user for a valid session token', async () => {
+    prismaMock.session.findUnique = jest.fn().mockResolvedValue({
+      expiresAt: new Date(Date.now() + 60_000),
+      user: {
+        id: 7,
+        name: 'Alice',
+        email: 'alice@example.com',
+      },
+    });
+
+    await expect(service.getCurrentUser('session-token')).resolves.toEqual({
+      id: 7,
+      name: 'Alice',
+      email: 'alice@example.com',
+    });
+  });
+
   it('upgrades a legacy blank-password user during registration', async () => {
     prismaMock.user.findUnique = jest.fn().mockResolvedValue({
       id: 3,

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -137,6 +137,33 @@ export class AuthService {
     };
   }
 
+  async getCurrentUser(rawToken?: string) {
+    if (!rawToken) {
+      return null;
+    }
+
+    const session = await this.prisma.session.findUnique({
+      where: {
+        tokenHash: hashSessionToken(rawToken),
+      },
+      include: {
+        user: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+          },
+        },
+      },
+    });
+
+    if (!session || session.expiresAt <= new Date()) {
+      return null;
+    }
+
+    return session.user;
+  }
+
   async forgotPassword(dto: ForgotPasswordDto) {
     const email = dto.email.trim().toLowerCase();
     const user = await this.prisma.user.findUnique({

--- a/apps/api/src/auth/auth.utils.ts
+++ b/apps/api/src/auth/auth.utils.ts
@@ -39,6 +39,10 @@ export function createResetToken() {
   return randomBytes(32).toString('hex');
 }
 
+export function createInviteToken() {
+  return randomBytes(32).toString('hex');
+}
+
 export function createJoinCode() {
   return randomBytes(4).toString('hex').toUpperCase();
 }

--- a/apps/api/src/families/dto/accept-family-invite.dto.ts
+++ b/apps/api/src/families/dto/accept-family-invite.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class AcceptFamilyInviteDto {
+  @IsString()
+  @IsNotEmpty()
+  token: string;
+}

--- a/apps/api/src/families/families.controller.spec.ts
+++ b/apps/api/src/families/families.controller.spec.ts
@@ -1,0 +1,43 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthGuard } from '../auth/auth.guard';
+import { FamiliesController } from './families.controller';
+import { FamiliesService } from './families.service';
+
+describe('FamiliesController', () => {
+  let controller: FamiliesController;
+  const serviceMock = {
+    listFamilies: jest.fn(),
+    createFamily: jest.fn(),
+    listInvites: jest.fn(),
+    createInvite: jest.fn(),
+    acceptInvite: jest.fn(),
+    revokeInvite: jest.fn(),
+  } as unknown as FamiliesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [FamiliesController],
+      providers: [{ provide: FamiliesService, useValue: serviceMock }],
+    })
+      .overrideGuard(AuthGuard)
+      .useValue({ canActivate: jest.fn(() => true) })
+      .compile();
+
+    controller = module.get<FamiliesController>(FamiliesController);
+    jest.clearAllMocks();
+  });
+
+  it('passes invite acceptance through to the service', async () => {
+    serviceMock.acceptInvite = jest.fn().mockResolvedValue({ id: 1 });
+
+    await controller.acceptInvite(
+      { id: 7, name: 'Alice', email: 'alice@example.com' },
+      { token: 'invite-token' },
+    );
+
+    expect(serviceMock.acceptInvite).toHaveBeenCalledWith(7, {
+      token: 'invite-token',
+    });
+  });
+});

--- a/apps/api/src/families/families.controller.ts
+++ b/apps/api/src/families/families.controller.ts
@@ -13,7 +13,6 @@ import { CurrentUser } from '../auth/current-user.decorator';
 import type { AuthenticatedUser } from '../auth/auth.types';
 import { AcceptFamilyInviteDto } from './dto/accept-family-invite.dto';
 import { CreateFamilyDto } from './dto/create-family.dto';
-import { JoinFamilyDto } from './dto/join-family.dto';
 import { FamiliesService } from './families.service';
 
 @Controller('families')
@@ -32,14 +31,6 @@ export class FamiliesController {
     @Body() dto: CreateFamilyDto,
   ) {
     return this.familiesService.createFamily(user.id, dto);
-  }
-
-  @Post('join')
-  joinFamily(
-    @CurrentUser() user: AuthenticatedUser,
-    @Body() dto: JoinFamilyDto,
-  ) {
-    return this.familiesService.joinFamily(user.id, dto);
   }
 
   @Get(':familyId/invites')

--- a/apps/api/src/families/families.controller.ts
+++ b/apps/api/src/families/families.controller.ts
@@ -1,10 +1,20 @@
-import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  Param,
+  ParseIntPipe,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import { AuthGuard } from '../auth/auth.guard';
 import { CurrentUser } from '../auth/current-user.decorator';
 import type { AuthenticatedUser } from '../auth/auth.types';
-import { FamiliesService } from './families.service';
+import { AcceptFamilyInviteDto } from './dto/accept-family-invite.dto';
 import { CreateFamilyDto } from './dto/create-family.dto';
 import { JoinFamilyDto } from './dto/join-family.dto';
+import { FamiliesService } from './families.service';
 
 @Controller('families')
 @UseGuards(AuthGuard)
@@ -30,5 +40,38 @@ export class FamiliesController {
     @Body() dto: JoinFamilyDto,
   ) {
     return this.familiesService.joinFamily(user.id, dto);
+  }
+
+  @Get(':familyId/invites')
+  listInvites(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('familyId', ParseIntPipe) familyId: number,
+  ) {
+    return this.familiesService.listInvites(user.id, familyId);
+  }
+
+  @Post(':familyId/invites')
+  createInvite(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('familyId', ParseIntPipe) familyId: number,
+  ) {
+    return this.familiesService.createInvite(user.id, familyId);
+  }
+
+  @Post('invites/accept')
+  acceptInvite(
+    @CurrentUser() user: AuthenticatedUser,
+    @Body() dto: AcceptFamilyInviteDto,
+  ) {
+    return this.familiesService.acceptInvite(user.id, dto);
+  }
+
+  @Post('invites/:inviteId/revoke')
+  @HttpCode(200)
+  revokeInvite(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('inviteId', ParseIntPipe) inviteId: number,
+  ) {
+    return this.familiesService.revokeInvite(user.id, inviteId);
   }
 }

--- a/apps/api/src/families/families.service.spec.ts
+++ b/apps/api/src/families/families.service.spec.ts
@@ -4,7 +4,6 @@ import {
   ConflictException,
   ForbiddenException,
 } from '@nestjs/common';
-import { Prisma } from '@prisma/client';
 import { Test, TestingModule } from '@nestjs/testing';
 import { PrismaService } from '../prisma/prisma.service';
 import { FamiliesService } from './families.service';
@@ -50,7 +49,6 @@ describe('FamiliesService', () => {
     prismaMock.family.create = jest.fn().mockResolvedValue({
       id: 1,
       name: 'Smith Family',
-      joinCode: 'ABCD1234',
       creatorId: 7,
       createdAt: new Date('2026-03-25T10:00:00.000Z'),
       updatedAt: new Date('2026-03-25T10:00:00.000Z'),
@@ -91,7 +89,6 @@ describe('FamiliesService', () => {
         family: {
           id: 1,
           name: 'Smith Family',
-          joinCode: 'ABCD1234',
           creatorId: 7,
           createdAt: new Date('2026-03-25T10:00:00.000Z'),
           updatedAt: new Date('2026-03-25T10:00:00.000Z'),
@@ -121,7 +118,6 @@ describe('FamiliesService', () => {
       family: {
         id: 1,
         name: 'Smith Family',
-        joinCode: 'ABCD1234',
         creatorId: 7,
         createdAt: new Date('2026-03-25T10:00:00.000Z'),
         updatedAt: new Date('2026-03-25T10:00:00.000Z'),
@@ -164,7 +160,6 @@ describe('FamiliesService', () => {
       family: {
         id: 1,
         name: 'Smith Family',
-        joinCode: 'ABCD1234',
         creatorId: 7,
         createdAt: new Date('2026-03-25T10:00:00.000Z'),
         updatedAt: new Date('2026-03-25T10:00:00.000Z'),
@@ -198,7 +193,6 @@ describe('FamiliesService', () => {
     prismaMock.family.findUnique = jest.fn().mockResolvedValue({
       id: 1,
       name: 'Smith Family',
-      joinCode: 'ABCD1234',
       creatorId: 7,
       createdAt: new Date('2026-03-25T10:00:00.000Z'),
       updatedAt: new Date('2026-03-25T10:00:00.000Z'),
@@ -282,7 +276,6 @@ describe('FamiliesService', () => {
       family: {
         id: 1,
         name: 'Smith Family',
-        joinCode: 'ABCD1234',
         creatorId: 7,
         createdAt: new Date('2026-03-25T10:00:00.000Z'),
         updatedAt: new Date('2026-03-25T10:00:00.000Z'),
@@ -296,32 +289,6 @@ describe('FamiliesService', () => {
     await expect(service.revokeInvite(7, 5)).resolves.toEqual({
       success: true,
     });
-  });
-
-  it('maps unique-constraint races on family join to ConflictException', async () => {
-    prismaMock.family.findUnique = jest
-      .fn()
-      .mockResolvedValueOnce({
-        id: 1,
-        name: 'Smith Family',
-        joinCode: 'ABCD1234',
-        creatorId: 7,
-        createdAt: new Date('2026-03-25T10:00:00.000Z'),
-        updatedAt: new Date('2026-03-25T10:00:00.000Z'),
-        memberships: [],
-      })
-      .mockResolvedValueOnce(null);
-    prismaMock.familyMembership.create = jest.fn().mockRejectedValue(
-      new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
-        code: 'P2002',
-        clientVersion: 'test',
-        meta: {},
-      }),
-    );
-
-    await expect(
-      service.joinFamily(9, { joinCode: 'ABCD1234' }),
-    ).rejects.toBeInstanceOf(ConflictException);
   });
 
   it('requires a shared family for cross-user wishlist reads', async () => {

--- a/apps/api/src/families/families.service.spec.ts
+++ b/apps/api/src/families/families.service.spec.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/unbound-method */
 import {
+  BadRequestException,
   ConflictException,
   ForbiddenException,
-  NotFoundException,
 } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { Test, TestingModule } from '@nestjs/testing';
@@ -16,11 +16,21 @@ describe('FamiliesService', () => {
       findUnique: jest.fn(),
       create: jest.fn(),
     },
+    familyInvite: {
+      findMany: jest.fn(),
+      create: jest.fn(),
+      findFirst: jest.fn(),
+      findUnique: jest.fn(),
+      updateMany: jest.fn(),
+      update: jest.fn(),
+    },
     familyMembership: {
       findMany: jest.fn(),
       findFirst: jest.fn(),
+      findUnique: jest.fn(),
       create: jest.fn(),
     },
+    $transaction: jest.fn(),
   } as unknown as PrismaService;
 
   beforeEach(async () => {
@@ -35,7 +45,7 @@ describe('FamiliesService', () => {
     jest.clearAllMocks();
   });
 
-  it('creates a family and adds the creator as a member', async () => {
+  it('creates a family and adds the creator as an admin', async () => {
     prismaMock.family.findUnique = jest.fn().mockResolvedValue(null);
     prismaMock.family.create = jest.fn().mockResolvedValue({
       id: 1,
@@ -46,6 +56,8 @@ describe('FamiliesService', () => {
       updatedAt: new Date('2026-03-25T10:00:00.000Z'),
       memberships: [
         {
+          userId: 7,
+          role: 'admin',
           user: {
             id: 7,
             name: 'Alice',
@@ -61,85 +73,244 @@ describe('FamiliesService', () => {
       expect.objectContaining({
         data: expect.objectContaining({
           creatorId: 7,
-          name: 'Smith Family',
           memberships: {
             create: {
               userId: 7,
+              role: 'admin',
             },
           },
         }),
       }),
     );
-    expect(result.memberCount).toBe(1);
+    expect(result.currentUserRole).toBe('admin');
   });
 
-  it('joins a family by join code', async () => {
-    prismaMock.family.findUnique = jest.fn().mockResolvedValue({
-      id: 1,
-      name: 'Smith Family',
-      joinCode: 'ABCD1234',
-      creatorId: 7,
-      memberships: [
-        {
-          userId: 7,
-          user: {
-            id: 7,
-            name: 'Alice',
-            email: 'alice@example.com',
-          },
+  it('returns the caller role in family summaries', async () => {
+    prismaMock.familyMembership.findMany = jest.fn().mockResolvedValue([
+      {
+        family: {
+          id: 1,
+          name: 'Smith Family',
+          joinCode: 'ABCD1234',
+          creatorId: 7,
+          createdAt: new Date('2026-03-25T10:00:00.000Z'),
+          updatedAt: new Date('2026-03-25T10:00:00.000Z'),
+          memberships: [
+            {
+              userId: 7,
+              role: 'admin',
+              user: {
+                id: 7,
+                name: 'Alice',
+                email: 'alice@example.com',
+              },
+            },
+          ],
         },
-      ],
-    });
-    prismaMock.familyMembership.create = jest.fn().mockResolvedValue({
+      },
+    ]);
+
+    const result = await service.listFamilies(7);
+
+    expect(result[0]?.currentUserRole).toBe('admin');
+  });
+
+  it('creates invite links for admins', async () => {
+    prismaMock.familyMembership.findUnique = jest.fn().mockResolvedValue({
+      role: 'admin',
       family: {
         id: 1,
         name: 'Smith Family',
         joinCode: 'ABCD1234',
         creatorId: 7,
         createdAt: new Date('2026-03-25T10:00:00.000Z'),
-        updatedAt: new Date('2026-03-25T10:05:00.000Z'),
+        updatedAt: new Date('2026-03-25T10:00:00.000Z'),
         memberships: [
           {
+            userId: 7,
+            role: 'admin',
             user: {
               id: 7,
               name: 'Alice',
               email: 'alice@example.com',
             },
           },
-          {
-            user: {
-              id: 9,
-              name: 'Bob',
-              email: 'bob@example.com',
-            },
-          },
         ],
       },
     });
+    prismaMock.familyInvite.create = jest.fn().mockResolvedValue({
+      id: 99,
+      familyId: 1,
+      createdAt: new Date('2026-03-25T10:00:00.000Z'),
+      updatedAt: new Date('2026-03-25T10:00:00.000Z'),
+      expiresAt: new Date('2026-04-01T10:00:00.000Z'),
+      usedAt: null,
+      revokedAt: null,
+      createdByUser: {
+        id: 7,
+        name: 'Alice',
+        email: 'alice@example.com',
+      },
+    });
 
-    const result = await service.joinFamily(9, { joinCode: 'abcd1234' });
+    const result = await service.createInvite(7, 1);
 
-    expect(prismaMock.family.findUnique).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { joinCode: 'ABCD1234' },
-      }),
-    );
-    expect(prismaMock.familyMembership.create).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: { userId: 9, familyId: 1 },
-      }),
-    );
-    expect(result.memberCount).toBe(2);
+    expect(result.inviteUrl).toContain('inviteToken=');
   });
 
-  it('maps unique-constraint races on family join to ConflictException', async () => {
+  it('blocks invite creation for non-admin members', async () => {
+    prismaMock.familyMembership.findUnique = jest.fn().mockResolvedValue({
+      role: 'member',
+      family: {
+        id: 1,
+        name: 'Smith Family',
+        joinCode: 'ABCD1234',
+        creatorId: 7,
+        createdAt: new Date('2026-03-25T10:00:00.000Z'),
+        updatedAt: new Date('2026-03-25T10:00:00.000Z'),
+        memberships: [],
+      },
+    });
+
+    await expect(service.createInvite(9, 1)).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+  });
+
+  it('accepts an invite and joins as a member', async () => {
+    prismaMock.$transaction = jest
+      .fn()
+      .mockImplementation(
+        async (callback: (tx: typeof prismaMock) => Promise<unknown>) =>
+          callback(prismaMock),
+      );
+    prismaMock.familyInvite.findFirst = jest.fn().mockResolvedValue({
+      id: 5,
+      familyId: 1,
+    });
+    prismaMock.familyMembership.findUnique = jest.fn().mockResolvedValue(null);
+    prismaMock.familyInvite.updateMany = jest
+      .fn()
+      .mockResolvedValue({ count: 1 });
+    prismaMock.familyMembership.create = jest.fn().mockResolvedValue({
+      id: 10,
+    });
     prismaMock.family.findUnique = jest.fn().mockResolvedValue({
       id: 1,
       name: 'Smith Family',
       joinCode: 'ABCD1234',
       creatorId: 7,
-      memberships: [],
+      createdAt: new Date('2026-03-25T10:00:00.000Z'),
+      updatedAt: new Date('2026-03-25T10:00:00.000Z'),
+      memberships: [
+        {
+          userId: 7,
+          role: 'admin',
+          user: {
+            id: 7,
+            name: 'Alice',
+            email: 'alice@example.com',
+          },
+        },
+        {
+          userId: 9,
+          role: 'member',
+          user: {
+            id: 9,
+            name: 'Bob',
+            email: 'bob@example.com',
+          },
+        },
+      ],
     });
+
+    const result = await service.acceptInvite(9, { token: 'invite-token' });
+
+    expect(prismaMock.familyMembership.create).toHaveBeenCalledWith({
+      data: {
+        userId: 9,
+        familyId: 1,
+        role: 'member',
+      },
+    });
+    expect(result.currentUserRole).toBe('member');
+  });
+
+  it('rejects expired or invalid invite tokens', async () => {
+    prismaMock.$transaction = jest
+      .fn()
+      .mockImplementation(
+        async (callback: (tx: typeof prismaMock) => Promise<unknown>) =>
+          callback(prismaMock),
+      );
+    prismaMock.familyInvite.findFirst = jest.fn().mockResolvedValue(null);
+
+    await expect(
+      service.acceptInvite(9, { token: 'missing-token' }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('rejects duplicate invite acceptance for existing members', async () => {
+    prismaMock.$transaction = jest
+      .fn()
+      .mockImplementation(
+        async (callback: (tx: typeof prismaMock) => Promise<unknown>) =>
+          callback(prismaMock),
+      );
+    prismaMock.familyInvite.findFirst = jest.fn().mockResolvedValue({
+      id: 5,
+      familyId: 1,
+    });
+    prismaMock.familyMembership.findUnique = jest.fn().mockResolvedValue({
+      id: 10,
+    });
+
+    await expect(
+      service.acceptInvite(9, { token: 'invite-token' }),
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('revokes active invites for admins', async () => {
+    prismaMock.familyInvite.findUnique = jest.fn().mockResolvedValue({
+      id: 5,
+      familyId: 1,
+      usedAt: null,
+      revokedAt: null,
+    });
+    prismaMock.familyMembership.findUnique = jest.fn().mockResolvedValue({
+      role: 'admin',
+      family: {
+        id: 1,
+        name: 'Smith Family',
+        joinCode: 'ABCD1234',
+        creatorId: 7,
+        createdAt: new Date('2026-03-25T10:00:00.000Z'),
+        updatedAt: new Date('2026-03-25T10:00:00.000Z'),
+        memberships: [],
+      },
+    });
+    prismaMock.familyInvite.update = jest.fn().mockResolvedValue({
+      id: 5,
+    });
+
+    await expect(service.revokeInvite(7, 5)).resolves.toEqual({
+      success: true,
+    });
+  });
+
+  it('maps unique-constraint races on family join to ConflictException', async () => {
+    prismaMock.family.findUnique = jest
+      .fn()
+      .mockResolvedValueOnce({
+        id: 1,
+        name: 'Smith Family',
+        joinCode: 'ABCD1234',
+        creatorId: 7,
+        createdAt: new Date('2026-03-25T10:00:00.000Z'),
+        updatedAt: new Date('2026-03-25T10:00:00.000Z'),
+        memberships: [],
+      })
+      .mockResolvedValueOnce(null);
     prismaMock.familyMembership.create = jest.fn().mockRejectedValue(
       new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
         code: 'P2002',
@@ -151,33 +322,6 @@ describe('FamiliesService', () => {
     await expect(
       service.joinFamily(9, { joinCode: 'ABCD1234' }),
     ).rejects.toBeInstanceOf(ConflictException);
-  });
-
-  it('rejects duplicate family joins', async () => {
-    prismaMock.family.findUnique = jest.fn().mockResolvedValue({
-      id: 1,
-      name: 'Smith Family',
-      joinCode: 'ABCD1234',
-      creatorId: 7,
-      memberships: [
-        {
-          userId: 9,
-          user: { id: 9, name: 'Bob', email: 'bob@example.com' },
-        },
-      ],
-    });
-
-    await expect(
-      service.joinFamily(9, { joinCode: 'ABCD1234' }),
-    ).rejects.toBeInstanceOf(ConflictException);
-  });
-
-  it('rejects unknown family join codes', async () => {
-    prismaMock.family.findUnique = jest.fn().mockResolvedValue(null);
-
-    await expect(
-      service.joinFamily(9, { joinCode: 'MISSING' }),
-    ).rejects.toBeInstanceOf(NotFoundException);
   });
 
   it('requires a shared family for cross-user wishlist reads', async () => {

--- a/apps/api/src/families/families.service.ts
+++ b/apps/api/src/families/families.service.ts
@@ -14,7 +14,6 @@ import {
 import { PrismaService } from '../prisma/prisma.service';
 import { AcceptFamilyInviteDto } from './dto/accept-family-invite.dto';
 import { CreateFamilyDto } from './dto/create-family.dto';
-import { JoinFamilyDto } from './dto/join-family.dto';
 
 const FAMILY_MEMBER_SELECT = {
   id: true,
@@ -71,7 +70,6 @@ export class FamiliesService {
     return {
       id: family.id,
       name: family.name,
-      joinCode: family.joinCode,
       creatorId: family.creatorId,
       currentUserRole: currentMembership.role,
       memberCount: family.memberships.length,
@@ -183,55 +181,6 @@ export class FamiliesService {
     });
 
     return this.mapFamilySummary(family, currentUserId);
-  }
-
-  async joinFamily(currentUserId: number, dto: JoinFamilyDto) {
-    const joinCode = dto.joinCode.trim().toUpperCase();
-    const family = await this.prisma.family.findUnique({
-      where: { joinCode },
-      include: FAMILY_INCLUDE,
-    });
-
-    if (!family) {
-      throw new NotFoundException('Family not found');
-    }
-
-    const existingMembership = family.memberships.find(
-      (membership) => membership.userId === currentUserId,
-    );
-    if (existingMembership) {
-      throw new ConflictException('You are already a member of this family');
-    }
-
-    try {
-      await this.prisma.familyMembership.create({
-        data: {
-          userId: currentUserId,
-          familyId: family.id,
-          role: 'member',
-        },
-      });
-    } catch (error) {
-      if (
-        error instanceof Prisma.PrismaClientKnownRequestError &&
-        error.code === 'P2002'
-      ) {
-        throw new ConflictException('You are already a member of this family');
-      }
-
-      throw error;
-    }
-
-    const updatedFamily = await this.prisma.family.findUnique({
-      where: { id: family.id },
-      include: FAMILY_INCLUDE,
-    });
-
-    if (!updatedFamily) {
-      throw new NotFoundException('Family not found');
-    }
-
-    return this.mapFamilySummary(updatedFamily, currentUserId);
   }
 
   async listInvites(currentUserId: number, familyId: number) {

--- a/apps/api/src/families/families.service.ts
+++ b/apps/api/src/families/families.service.ts
@@ -1,34 +1,98 @@
 import {
+  BadRequestException,
   ConflictException,
   ForbiddenException,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
+import {
+  createInviteToken,
+  createJoinCode,
+  hashSessionToken,
+} from '../auth/auth.utils';
 import { PrismaService } from '../prisma/prisma.service';
-import { createJoinCode } from '../auth/auth.utils';
+import { AcceptFamilyInviteDto } from './dto/accept-family-invite.dto';
 import { CreateFamilyDto } from './dto/create-family.dto';
 import { JoinFamilyDto } from './dto/join-family.dto';
 
-type FamilySummaryRecord = {
-  id: number;
-  name: string;
-  joinCode: string;
-  creatorId: number;
-  memberships: Array<{
-    user: {
-      id: number;
-      name: string;
-      email: string;
+const FAMILY_MEMBER_SELECT = {
+  id: true,
+  name: true,
+  email: true,
+} as const;
+
+const FAMILY_INCLUDE = {
+  memberships: {
+    include: {
+      user: {
+        select: FAMILY_MEMBER_SELECT,
+      },
+    },
+    orderBy: {
+      createdAt: 'asc',
+    },
+  },
+} satisfies Prisma.FamilyInclude;
+
+type FamilyWithMemberships = Prisma.FamilyGetPayload<{
+  include: typeof FAMILY_INCLUDE;
+}>;
+
+type FamilyInviteWithCreator = Prisma.FamilyInviteGetPayload<{
+  include: {
+    createdByUser: {
+      select: typeof FAMILY_MEMBER_SELECT;
     };
-  }>;
-  createdAt: Date;
-  updatedAt: Date;
-};
+  };
+}>;
 
 @Injectable()
 export class FamiliesService {
   constructor(private readonly prisma: PrismaService) {}
+
+  private buildInviteUrl(rawToken: string) {
+    const baseUrl = process.env.WEB_APP_URL ?? 'http://localhost:5173';
+    return `${baseUrl}/?inviteToken=${encodeURIComponent(rawToken)}`;
+  }
+
+  private mapFamilySummary(
+    family: FamilyWithMemberships,
+    currentUserId: number,
+  ) {
+    const currentMembership = family.memberships.find(
+      (membership) => membership.userId === currentUserId,
+    );
+
+    if (!currentMembership) {
+      throw new ForbiddenException('You are not a member of this family');
+    }
+
+    return {
+      id: family.id,
+      name: family.name,
+      joinCode: family.joinCode,
+      creatorId: family.creatorId,
+      currentUserRole: currentMembership.role,
+      memberCount: family.memberships.length,
+      members: family.memberships.map((membership) => membership.user),
+      createdAt: family.createdAt,
+      updatedAt: family.updatedAt,
+    };
+  }
+
+  private mapInvite(invite: FamilyInviteWithCreator) {
+    return {
+      id: invite.id,
+      familyId: invite.familyId,
+      createdByUser: invite.createdByUser,
+      expiresAt: invite.expiresAt,
+      usedAt: invite.usedAt,
+      revokedAt: invite.revokedAt,
+      createdAt: invite.createdAt,
+      updatedAt: invite.updatedAt,
+    };
+  }
 
   private async generateUniqueJoinCode() {
     for (let attempt = 0; attempt < 5; attempt += 1) {
@@ -46,42 +110,58 @@ export class FamiliesService {
     throw new ConflictException('Unable to generate a unique join code');
   }
 
+  private async getFamilyForMember(currentUserId: number, familyId: number) {
+    const membership = await this.prisma.familyMembership.findUnique({
+      where: {
+        userId_familyId: {
+          userId: currentUserId,
+          familyId,
+        },
+      },
+      include: {
+        family: {
+          include: FAMILY_INCLUDE,
+        },
+      },
+    });
+
+    if (!membership) {
+      throw new NotFoundException('Family not found');
+    }
+
+    return {
+      family: membership.family,
+      membership,
+    };
+  }
+
+  private async assertFamilyAdmin(currentUserId: number, familyId: number) {
+    const { family, membership } = await this.getFamilyForMember(
+      currentUserId,
+      familyId,
+    );
+
+    if (membership.role !== 'admin') {
+      throw new ForbiddenException('Only family admins can manage invites');
+    }
+
+    return family;
+  }
+
   async listFamilies(currentUserId: number) {
     const memberships = await this.prisma.familyMembership.findMany({
       where: { userId: currentUserId },
       orderBy: { createdAt: 'asc' },
       include: {
         family: {
-          include: {
-            memberships: {
-              include: {
-                user: {
-                  select: {
-                    id: true,
-                    name: true,
-                    email: true,
-                  },
-                },
-              },
-              orderBy: {
-                createdAt: 'asc',
-              },
-            },
-          },
+          include: FAMILY_INCLUDE,
         },
       },
     });
 
-    return memberships.map(({ family }) => ({
-      id: family.id,
-      name: family.name,
-      joinCode: family.joinCode,
-      creatorId: family.creatorId,
-      memberCount: family.memberships.length,
-      members: family.memberships.map((membership) => membership.user),
-      createdAt: family.createdAt,
-      updatedAt: family.updatedAt,
-    }));
+    return memberships.map(({ family }) =>
+      this.mapFamilySummary(family, currentUserId),
+    );
   }
 
   async createFamily(currentUserId: number, dto: CreateFamilyDto) {
@@ -95,53 +175,21 @@ export class FamiliesService {
         memberships: {
           create: {
             userId: currentUserId,
+            role: 'admin',
           },
         },
       },
-      include: {
-        memberships: {
-          include: {
-            user: {
-              select: {
-                id: true,
-                name: true,
-                email: true,
-              },
-            },
-          },
-        },
-      },
+      include: FAMILY_INCLUDE,
     });
 
-    return {
-      id: family.id,
-      name: family.name,
-      joinCode: family.joinCode,
-      creatorId: family.creatorId,
-      memberCount: family.memberships.length,
-      members: family.memberships.map((membership) => membership.user),
-      createdAt: family.createdAt,
-      updatedAt: family.updatedAt,
-    };
+    return this.mapFamilySummary(family, currentUserId);
   }
 
   async joinFamily(currentUserId: number, dto: JoinFamilyDto) {
     const joinCode = dto.joinCode.trim().toUpperCase();
     const family = await this.prisma.family.findUnique({
       where: { joinCode },
-      include: {
-        memberships: {
-          include: {
-            user: {
-              select: {
-                id: true,
-                name: true,
-                email: true,
-              },
-            },
-          },
-        },
-      },
+      include: FAMILY_INCLUDE,
     });
 
     if (!family) {
@@ -155,32 +203,14 @@ export class FamiliesService {
       throw new ConflictException('You are already a member of this family');
     }
 
-    let membershipFamily: FamilySummaryRecord;
     try {
-      const membership = await this.prisma.familyMembership.create({
+      await this.prisma.familyMembership.create({
         data: {
           userId: currentUserId,
           familyId: family.id,
-        },
-        include: {
-          family: {
-            include: {
-              memberships: {
-                include: {
-                  user: {
-                    select: {
-                      id: true,
-                      name: true,
-                      email: true,
-                    },
-                  },
-                },
-              },
-            },
-          },
+          role: 'member',
         },
       });
-      membershipFamily = membership.family as FamilySummaryRecord;
     } catch (error) {
       if (
         error instanceof Prisma.PrismaClientKnownRequestError &&
@@ -192,18 +222,188 @@ export class FamiliesService {
       throw error;
     }
 
+    const updatedFamily = await this.prisma.family.findUnique({
+      where: { id: family.id },
+      include: FAMILY_INCLUDE,
+    });
+
+    if (!updatedFamily) {
+      throw new NotFoundException('Family not found');
+    }
+
+    return this.mapFamilySummary(updatedFamily, currentUserId);
+  }
+
+  async listInvites(currentUserId: number, familyId: number) {
+    await this.assertFamilyAdmin(currentUserId, familyId);
+
+    const invites = await this.prisma.familyInvite.findMany({
+      where: {
+        familyId,
+        revokedAt: null,
+        usedAt: null,
+        expiresAt: {
+          gt: new Date(),
+        },
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+      include: {
+        createdByUser: {
+          select: FAMILY_MEMBER_SELECT,
+        },
+      },
+    });
+
+    return invites.map((invite) => this.mapInvite(invite));
+  }
+
+  async createInvite(currentUserId: number, familyId: number) {
+    await this.assertFamilyAdmin(currentUserId, familyId);
+
+    const rawToken = createInviteToken();
+    const invite = await this.prisma.familyInvite.create({
+      data: {
+        tokenHash: hashSessionToken(rawToken),
+        familyId,
+        createdByUserId: currentUserId,
+        expiresAt: new Date(Date.now() + 1000 * 60 * 60 * 24 * 7),
+      },
+      include: {
+        createdByUser: {
+          select: FAMILY_MEMBER_SELECT,
+        },
+      },
+    });
+
     return {
-      id: membershipFamily.id,
-      name: membershipFamily.name,
-      joinCode: membershipFamily.joinCode,
-      creatorId: membershipFamily.creatorId,
-      memberCount: membershipFamily.memberships.length,
-      members: membershipFamily.memberships.map(
-        (familyMembership) => familyMembership.user,
-      ),
-      createdAt: membershipFamily.createdAt,
-      updatedAt: membershipFamily.updatedAt,
+      ...this.mapInvite(invite),
+      inviteUrl: this.buildInviteUrl(rawToken),
     };
+  }
+
+  async acceptInvite(currentUserId: number, dto: AcceptFamilyInviteDto) {
+    const tokenHash = hashSessionToken(dto.token.trim());
+    const now = new Date();
+
+    const familyId = await this.prisma.$transaction(async (tx) => {
+      const invite = await tx.familyInvite.findFirst({
+        where: {
+          tokenHash,
+          usedAt: null,
+          revokedAt: null,
+          expiresAt: {
+            gt: now,
+          },
+        },
+        select: {
+          id: true,
+          familyId: true,
+        },
+      });
+
+      if (!invite) {
+        throw new BadRequestException('Invite link is invalid or expired');
+      }
+
+      const existingMembership = await tx.familyMembership.findUnique({
+        where: {
+          userId_familyId: {
+            userId: currentUserId,
+            familyId: invite.familyId,
+          },
+        },
+        select: { id: true },
+      });
+
+      if (existingMembership) {
+        throw new ConflictException('You are already a member of this family');
+      }
+
+      const consumeResult = await tx.familyInvite.updateMany({
+        where: {
+          id: invite.id,
+          usedAt: null,
+          revokedAt: null,
+          expiresAt: {
+            gt: now,
+          },
+        },
+        data: {
+          usedAt: now,
+        },
+      });
+
+      if (consumeResult.count !== 1) {
+        throw new BadRequestException('Invite link is invalid or expired');
+      }
+
+      try {
+        await tx.familyMembership.create({
+          data: {
+            userId: currentUserId,
+            familyId: invite.familyId,
+            role: 'member',
+          },
+        });
+      } catch (error) {
+        if (
+          error instanceof Prisma.PrismaClientKnownRequestError &&
+          error.code === 'P2002'
+        ) {
+          throw new ConflictException(
+            'You are already a member of this family',
+          );
+        }
+
+        throw error;
+      }
+
+      return invite.familyId;
+    });
+
+    const family = await this.prisma.family.findUnique({
+      where: { id: familyId },
+      include: FAMILY_INCLUDE,
+    });
+
+    if (!family) {
+      throw new NotFoundException('Family not found');
+    }
+
+    return this.mapFamilySummary(family, currentUserId);
+  }
+
+  async revokeInvite(currentUserId: number, inviteId: number) {
+    const invite = await this.prisma.familyInvite.findUnique({
+      where: { id: inviteId },
+      select: {
+        id: true,
+        familyId: true,
+        usedAt: true,
+        revokedAt: true,
+      },
+    });
+
+    if (!invite) {
+      throw new NotFoundException('Invite not found');
+    }
+
+    await this.assertFamilyAdmin(currentUserId, invite.familyId);
+
+    if (invite.revokedAt || invite.usedAt) {
+      throw new BadRequestException('Invite is no longer active');
+    }
+
+    await this.prisma.familyInvite.update({
+      where: { id: invite.id },
+      data: {
+        revokedAt: new Date(),
+      },
+    });
+
+    return { success: true };
   }
 
   async assertSharedFamily(currentUserId: number, ownerId: number) {

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
 import { AppModule } from './app.module';

--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -112,6 +112,10 @@
   margin: 1rem 0;
 }
 
+.family-forms-single {
+  grid-template-columns: 1fr;
+}
+
 .primary-action {
   background: #2563eb;
   color: #fff;
@@ -164,6 +168,13 @@
   align-items: center;
 }
 
+.family-card-meta {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-top: 0.5rem;
+}
+
 .family-members {
   list-style: none;
   padding: 0;
@@ -181,6 +192,66 @@
 
 .family-members span {
   color: #64748b;
+}
+
+.invite-panel {
+  margin-top: 1rem;
+  border-top: 1px solid #dbeafe;
+  padding-top: 1rem;
+}
+
+.invite-panel-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+}
+
+.invite-link-card {
+  display: grid;
+  gap: 0.5rem;
+  margin: 1rem 0;
+}
+
+.invite-link-card input {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid #cbd5e1;
+  border-radius: 12px;
+  padding: 0.85rem 1rem;
+  font-size: 0.95rem;
+  background: #fff;
+}
+
+.invite-list {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.invite-list li {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+  border: 1px solid #dbeafe;
+  border-radius: 16px;
+  padding: 0.85rem 1rem;
+  background: #fff;
+}
+
+.role-pill {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  background: #dcfce7;
+  color: #166534;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: capitalize;
 }
 
 .pill {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,11 +2,19 @@ import { useCallback, useEffect, useState } from 'react';
 import type { FormEvent } from 'react';
 import './App.css';
 import { forgotPassword, getCurrentUser, login, logout, register, resetPassword } from './api/auth';
-import { createFamily, getFamilies, joinFamily } from './api/families';
+import {
+  acceptFamilyInvite,
+  createFamily,
+  createFamilyInvite,
+  getFamilies,
+  getFamilyInvites,
+  revokeFamilyInvite,
+} from './api/families';
 import { deleteWishListItem, getWishlistItems } from './api/wishlistItems';
 import { Card, DropDown, PaginationButtons, UserSearch } from './components/index';
 import type {
   AuthUser,
+  FamilyInviteSummary,
   FamilySummary,
   PaginationMeta,
   WishlistItemResponse,
@@ -42,13 +50,31 @@ function App() {
   const [meta, setMeta] = useState<PaginationMeta>();
   const [limit, setLimit] = useState(DEFAULT_LIMIT);
   const [families, setFamilies] = useState<FamilySummary[]>([]);
+  const [familyInvites, setFamilyInvites] = useState<Record<number, FamilyInviteSummary[]>>({});
+  const [latestInviteLinks, setLatestInviteLinks] = useState<Record<number, string>>({});
   const [familyLoading, setFamilyLoading] = useState(false);
   const [familyError, setFamilyError] = useState<string | null>(null);
   const [familyNotice, setFamilyNotice] = useState<string | null>(null);
   const [familyForm, setFamilyForm] = useState({
     createName: '',
-    joinCode: '',
   });
+  const [pendingInviteToken, setPendingInviteToken] = useState<string | null>(() => {
+    if (typeof window === 'undefined') {
+      return null;
+    }
+
+    return new URLSearchParams(window.location.search).get('inviteToken');
+  });
+  const [inviteAcceptanceLoading, setInviteAcceptanceLoading] = useState(false);
+  const [inviteActionFamilyId, setInviteActionFamilyId] = useState<number | null>(null);
+
+  const clearInviteTokenFromUrl = useCallback(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    window.history.replaceState({}, '', window.location.pathname);
+  }, []);
 
   const bootstrapUser = useCallback(async () => {
     setAuthLoading(true);
@@ -63,9 +89,28 @@ function App() {
     }
   }, []);
 
+  const fetchFamilyInvites = useCallback(async (familyList: FamilySummary[]) => {
+    const adminFamilies = familyList.filter((family) => family.currentUserRole === 'admin');
+
+    if (adminFamilies.length === 0) {
+      setFamilyInvites({});
+      return;
+    }
+
+    const entries = await Promise.all(
+      adminFamilies.map(async (family) => {
+        const invites = await getFamilyInvites(family.id);
+        return [family.id, invites] as const;
+      }),
+    );
+
+    setFamilyInvites(Object.fromEntries(entries));
+  }, []);
+
   const fetchFamilies = useCallback(async () => {
     if (!currentUser) {
       setFamilies([]);
+      setFamilyInvites({});
       return;
     }
 
@@ -73,13 +118,14 @@ function App() {
     try {
       const response = await getFamilies();
       setFamilies(response);
+      await fetchFamilyInvites(response);
       setFamilyError(null);
     } catch (err) {
       setFamilyError(err instanceof Error ? err.message : 'Failed to load families');
     } finally {
       setFamilyLoading(false);
     }
-  }, [currentUser]);
+  }, [currentUser, fetchFamilyInvites]);
 
   const fetchData = useCallback(async () => {
     if (!currentUser) {
@@ -113,6 +159,51 @@ function App() {
     void fetchData();
     void fetchFamilies();
   }, [currentUser, fetchData, fetchFamilies]);
+
+  useEffect(() => {
+    if (!pendingInviteToken) {
+      return;
+    }
+
+    if (!currentUser) {
+      setAuthNotice('Sign in to accept your family invite link.');
+      setAuthMode('login');
+      return;
+    }
+
+    if (inviteAcceptanceLoading) {
+      return;
+    }
+
+    const acceptInvite = async () => {
+      setInviteAcceptanceLoading(true);
+      setFamilyError(null);
+
+      try {
+        const family = await acceptFamilyInvite(pendingInviteToken);
+        setFamilyNotice(`You joined ${family.name}.`);
+        clearInviteTokenFromUrl();
+        setPendingInviteToken(null);
+        await fetchFamilies();
+        await fetchData();
+      } catch (err) {
+        setFamilyError(err instanceof Error ? err.message : 'Failed to accept family invite');
+        clearInviteTokenFromUrl();
+        setPendingInviteToken(null);
+      } finally {
+        setInviteAcceptanceLoading(false);
+      }
+    };
+
+    void acceptInvite();
+  }, [
+    clearInviteTokenFromUrl,
+    currentUser,
+    fetchData,
+    fetchFamilies,
+    inviteAcceptanceLoading,
+    pendingInviteToken,
+  ]);
 
   const handleBackPage = () => {
     setCurrentPage((page) => Math.max(1, page - 1));
@@ -252,6 +343,8 @@ function App() {
       setWishlistItems([]);
       setMeta(undefined);
       setFamilies([]);
+      setFamilyInvites({});
+      setLatestInviteLinks({});
       setError(null);
       setAuthError(null);
       setAuthNotice(null);
@@ -268,27 +361,66 @@ function App() {
     try {
       const family = await createFamily(familyForm.createName.trim());
       setFamilies((current) => [...current, family]);
-      setFamilyForm((current) => ({ ...current, createName: '' }));
-      setFamilyNotice(`Created ${family.name}. Share code ${family.joinCode} with relatives.`);
+      setFamilyForm({ createName: '' });
+      setFamilyNotice(`Created ${family.name}.`);
+      await fetchFamilies();
       await fetchData();
     } catch (err) {
       setFamilyError(err instanceof Error ? err.message : 'Failed to create family');
     }
   };
 
-  const handleJoinFamily = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
+  const handleCreateInvite = async (familyId: number) => {
     setFamilyError(null);
     setFamilyNotice(null);
+    setInviteActionFamilyId(familyId);
 
     try {
-      const family = await joinFamily(familyForm.joinCode.trim());
-      setFamilies((current) => [...current, family]);
-      setFamilyForm((current) => ({ ...current, joinCode: '' }));
-      setFamilyNotice(`Joined ${family.name}. You can now view shared family wishlists.`);
-      await fetchData();
+      const invite = await createFamilyInvite(familyId);
+      setLatestInviteLinks((current) => ({
+        ...current,
+        [familyId]: invite.inviteUrl,
+      }));
+      setFamilyInvites((current) => ({
+        ...current,
+        [familyId]: [
+          {
+            id: invite.id,
+            familyId: invite.familyId,
+            createdByUser: invite.createdByUser,
+            expiresAt: invite.expiresAt,
+            usedAt: invite.usedAt,
+            revokedAt: invite.revokedAt,
+            createdAt: invite.createdAt,
+            updatedAt: invite.updatedAt,
+          },
+          ...(current[familyId] ?? []),
+        ],
+      }));
+      setFamilyNotice('Invite link created. Share the link below.');
     } catch (err) {
-      setFamilyError(err instanceof Error ? err.message : 'Failed to join family');
+      setFamilyError(err instanceof Error ? err.message : 'Failed to create invite link');
+    } finally {
+      setInviteActionFamilyId(null);
+    }
+  };
+
+  const handleRevokeInvite = async (familyId: number, inviteId: number) => {
+    setFamilyError(null);
+    setFamilyNotice(null);
+    setInviteActionFamilyId(familyId);
+
+    try {
+      await revokeFamilyInvite(inviteId);
+      setFamilyInvites((current) => ({
+        ...current,
+        [familyId]: (current[familyId] ?? []).filter((invite) => invite.id !== inviteId),
+      }));
+      setFamilyNotice('Invite revoked.');
+    } catch (err) {
+      setFamilyError(err instanceof Error ? err.message : 'Failed to revoke invite');
+    } finally {
+      setInviteActionFamilyId(null);
     }
   };
 
@@ -463,9 +595,9 @@ function App() {
                 Wishlist visibility is limited to people who share at least one family with you.
               </p>
             </div>
-            {familyLoading && <span className="pill">Refreshing</span>}
+            {(familyLoading || inviteAcceptanceLoading) && <span className="pill">Refreshing</span>}
           </div>
-          <div className="family-forms">
+          <div className="family-forms family-forms-single">
             <form className="stacked-form" onSubmit={(event) => void handleCreateFamily(event)}>
               <label htmlFor="create-family-name">Create family</label>
               <input
@@ -484,24 +616,6 @@ function App() {
                 Create family
               </button>
             </form>
-            <form className="stacked-form" onSubmit={(event) => void handleJoinFamily(event)}>
-              <label htmlFor="join-family-code">Join family</label>
-              <input
-                id="join-family-code"
-                type="text"
-                placeholder="Invite code"
-                value={familyForm.joinCode}
-                onChange={(event) =>
-                  setFamilyForm((current) => ({
-                    ...current,
-                    joinCode: event.target.value.toUpperCase(),
-                  }))
-                }
-              />
-              <button type="submit" className="secondary-action">
-                Join with code
-              </button>
-            </form>
           </div>
           {familyError && <p className="form-error">{familyError}</p>}
           {familyNotice && <p className="form-notice">{familyNotice}</p>}
@@ -509,7 +623,7 @@ function App() {
             {families.length === 0 ? (
               <div className="empty-state">
                 <h3>No families yet</h3>
-                <p>Create one or join one to see other people’s wishlists.</p>
+                <p>Create one to start sharing invite links with relatives.</p>
               </div>
             ) : (
               families.map((family) => (
@@ -517,9 +631,11 @@ function App() {
                   <div className="family-card-header">
                     <div>
                       <h3>{family.name}</h3>
-                      <p className="subtle">Invite code: {family.joinCode}</p>
+                      <div className="family-card-meta">
+                        <span className="pill">{family.memberCount} members</span>
+                        <span className="role-pill">{family.currentUserRole}</span>
+                      </div>
                     </div>
-                    <span className="pill">{family.memberCount} members</span>
                   </div>
                   <ul className="family-members">
                     {family.members.map((member) => (
@@ -529,6 +645,52 @@ function App() {
                       </li>
                     ))}
                   </ul>
+                  {family.currentUserRole === 'admin' && (
+                    <div className="invite-panel">
+                      <div className="invite-panel-header">
+                        <h4>Invite links</h4>
+                        <button
+                          className="secondary-action"
+                          onClick={() => void handleCreateInvite(family.id)}
+                        >
+                          {inviteActionFamilyId === family.id ? 'Working...' : 'Create invite link'}
+                        </button>
+                      </div>
+                      {latestInviteLinks[family.id] && (
+                        <div className="invite-link-card">
+                          <label htmlFor={`invite-link-${family.id}`}>Latest invite link</label>
+                          <input
+                            id={`invite-link-${family.id}`}
+                            type="text"
+                            readOnly
+                            value={latestInviteLinks[family.id]}
+                          />
+                        </div>
+                      )}
+                      {(familyInvites[family.id] ?? []).length === 0 ? (
+                        <p className="subtle">No active invites.</p>
+                      ) : (
+                        <ul className="invite-list">
+                          {(familyInvites[family.id] ?? []).map((invite) => (
+                            <li key={invite.id}>
+                              <div>
+                                <strong>
+                                  Expires {new Date(invite.expiresAt).toLocaleString()}
+                                </strong>
+                                <p className="subtle">Created by {invite.createdByUser.name}</p>
+                              </div>
+                              <button
+                                className="secondary-action"
+                                onClick={() => void handleRevokeInvite(family.id, invite.id)}
+                              >
+                                Revoke
+                              </button>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    </div>
+                  )}
                 </article>
               ))
             )}

--- a/apps/web/src/api/auth.ts
+++ b/apps/web/src/api/auth.ts
@@ -57,7 +57,7 @@ export function logout() {
   });
 }
 type AuthResponse = {
-  user: AuthUser;
+  user: AuthUser | null;
 };
 
 export type ForgotPasswordResponse = {

--- a/apps/web/src/api/families.ts
+++ b/apps/web/src/api/families.ts
@@ -1,4 +1,4 @@
-import type { FamilySummary } from '../types/wishlist';
+import type { CreatedFamilyInvite, FamilyInviteSummary, FamilySummary } from '../types/wishlist';
 import { apiRequest } from './auth';
 
 export function getFamilies() {
@@ -16,5 +16,28 @@ export function joinFamily(joinCode: string) {
   return apiRequest<FamilySummary>('/api/families/join', {
     method: 'POST',
     body: JSON.stringify({ joinCode }),
+  });
+}
+
+export function getFamilyInvites(familyId: number) {
+  return apiRequest<FamilyInviteSummary[]>(`/api/families/${familyId}/invites`);
+}
+
+export function createFamilyInvite(familyId: number) {
+  return apiRequest<CreatedFamilyInvite>(`/api/families/${familyId}/invites`, {
+    method: 'POST',
+  });
+}
+
+export function acceptFamilyInvite(token: string) {
+  return apiRequest<FamilySummary>('/api/families/invites/accept', {
+    method: 'POST',
+    body: JSON.stringify({ token }),
+  });
+}
+
+export function revokeFamilyInvite(inviteId: number) {
+  return apiRequest<{ success: boolean }>(`/api/families/invites/${inviteId}/revoke`, {
+    method: 'POST',
   });
 }

--- a/apps/web/src/api/families.ts
+++ b/apps/web/src/api/families.ts
@@ -12,13 +12,6 @@ export function createFamily(name: string) {
   });
 }
 
-export function joinFamily(joinCode: string) {
-  return apiRequest<FamilySummary>('/api/families/join', {
-    method: 'POST',
-    body: JSON.stringify({ joinCode }),
-  });
-}
-
 export function getFamilyInvites(familyId: number) {
   return apiRequest<FamilyInviteSummary[]>(`/api/families/${familyId}/invites`);
 }

--- a/apps/web/src/types/wishlist.tsx
+++ b/apps/web/src/types/wishlist.tsx
@@ -18,15 +18,33 @@ export interface FamilyMember {
   name: string;
 }
 
+export type FamilyRole = 'admin' | 'member';
+
 export interface FamilySummary {
   id: number;
   name: string;
   joinCode: string;
   creatorId: number;
+  currentUserRole: FamilyRole;
   memberCount: number;
   members: FamilyMember[];
   createdAt: string;
   updatedAt: string;
+}
+
+export interface FamilyInviteSummary {
+  id: number;
+  familyId: number;
+  createdByUser: FamilyMember;
+  expiresAt: string;
+  usedAt: string | null;
+  revokedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreatedFamilyInvite extends FamilyInviteSummary {
+  inviteUrl: string;
 }
 
 export interface CardProps extends WishlistItemResponse {

--- a/apps/web/src/types/wishlist.tsx
+++ b/apps/web/src/types/wishlist.tsx
@@ -23,7 +23,6 @@ export type FamilyRole = 'admin' | 'member';
 export interface FamilySummary {
   id: number;
   name: string;
-  joinCode: string;
   creatorId: number;
   currentUserRole: FamilyRole;
   memberCount: number;


### PR DESCRIPTION
## Summary
- add family roles and admin-only invite link management on the API and web app
- add signed-in invite acceptance flow and family summaries that include the caller role
- make  return  when signed out so app bootstrap stays quiet instead of logging a 401

## Verification
- DATABASE_URL="file:./prisma/dev.db" npx prisma generate --schema prisma/schema.prisma
- DATABASE_URL="file:./prisma/dev.db" npx prisma migrate deploy --schema prisma/schema.prisma
- npm test -- --runInBand -w apps/api
- npm run build -w apps/api
- npm run build -w apps/web
- npx eslint apps/api/src/**/*.ts apps/web/src/**/*.tsx apps/web/src/**/*.ts

Closes #36
Closes #37