### PR TITLE
Milestone 7: Wishlist Management (owner features)

### DIFF
--- a/apps/api/prisma/migrations/20260327193339_add_timestamps_to_wishlist_and_item/migration.sql
+++ b/apps/api/prisma/migrations/20260327193339_add_timestamps_to_wishlist_and_item/migration.sql
@@ -1,0 +1,51 @@
+/*
+  Warnings:
+
+  - Added the required column `updatedAt` to the `Wishlist` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `updatedAt` to the `WishlistItem` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropIndex
+DROP INDEX "FamilyInvite_familyId_idx";
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_User" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "passwordHash" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+INSERT INTO "new_User" ("createdAt", "email", "id", "name", "passwordHash", "updatedAt") SELECT "createdAt", "email", "id", "name", "passwordHash", "updatedAt" FROM "User";
+DROP TABLE "User";
+ALTER TABLE "new_User" RENAME TO "User";
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+CREATE TABLE "new_Wishlist" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "title" TEXT NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Wishlist_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "new_Wishlist" ("id", "title", "userId", "createdAt", "updatedAt") SELECT "id", "title", "userId", CURRENT_TIMESTAMP, CURRENT_TIMESTAMP FROM "Wishlist";
+DROP TABLE "Wishlist";
+ALTER TABLE "new_Wishlist" RENAME TO "Wishlist";
+CREATE TABLE "new_WishlistItem" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "name" TEXT NOT NULL,
+    "url" TEXT,
+    "price" REAL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "wishlistId" INTEGER NOT NULL,
+    CONSTRAINT "WishlistItem_wishlistId_fkey" FOREIGN KEY ("wishlistId") REFERENCES "Wishlist" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "new_WishlistItem" ("createdAt", "updatedAt", "id", "name", "price", "url", "wishlistId") SELECT "createdAt", CURRENT_TIMESTAMP, "id", "name", "price", "url", "wishlistId" FROM "WishlistItem";
+DROP TABLE "WishlistItem";
+ALTER TABLE "new_WishlistItem" RENAME TO "WishlistItem";
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -88,14 +88,17 @@ model Wishlist {
   user      User           @relation(fields: [userId], references: [id])
   userId    Int
   items     WishlistItem[]
+  createdAt DateTime       @default(now())
+  updatedAt DateTime       @updatedAt
 }
 
 model WishlistItem {
-  id          Int     @id @default(autoincrement())
-  name        String
-  url         String?
-  price       Float?
-  createdAt   DateTime @default(now())
-  wishlist    Wishlist @relation(fields: [wishlistId], references: [id])
-  wishlistId  Int
+  id         Int      @id @default(autoincrement())
+  name       String
+  url        String?
+  price      Float?
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+  wishlist   Wishlist @relation(fields: [wishlistId], references: [id])
+  wishlistId Int
 }

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -6,6 +6,7 @@ import { FamiliesModule } from './families/families.module';
 import { PrismaModule } from './prisma/prisma.module';
 import { WishlistItemsModule } from './wishlist-items/wishlist-items.module';
 import { WishlistsModule } from './wishlists/wishlists.module';
+import { UsersModule } from './users/users.module';
 
 @Module({
   imports: [
@@ -14,6 +15,7 @@ import { WishlistsModule } from './wishlists/wishlists.module';
     FamiliesModule,
     WishlistItemsModule,
     WishlistsModule,
+    UsersModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/api/src/families/dto/add-family-member.dto.ts
+++ b/apps/api/src/families/dto/add-family-member.dto.ts
@@ -1,0 +1,7 @@
+import { IsInt, IsPositive } from 'class-validator';
+
+export class AddFamilyMemberDto {
+  @IsInt()
+  @IsPositive()
+  userId: number;
+}

--- a/apps/api/src/families/families.controller.ts
+++ b/apps/api/src/families/families.controller.ts
@@ -12,6 +12,7 @@ import { AuthGuard } from '../auth/auth.guard';
 import { CurrentUser } from '../auth/current-user.decorator';
 import type { AuthenticatedUser } from '../auth/auth.types';
 import { AcceptFamilyInviteDto } from './dto/accept-family-invite.dto';
+import { AddFamilyMemberDto } from './dto/add-family-member.dto';
 import { CreateFamilyDto } from './dto/create-family.dto';
 import { FamiliesService } from './families.service';
 
@@ -47,6 +48,15 @@ export class FamiliesController {
     @Param('familyId', ParseIntPipe) familyId: number,
   ) {
     return this.familiesService.createInvite(user.id, familyId);
+  }
+
+  @Post(':familyId/members')
+  addMember(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('familyId', ParseIntPipe) familyId: number,
+    @Body() dto: AddFamilyMemberDto,
+  ) {
+    return this.familiesService.addMember(user.id, familyId, dto);
   }
 
   @Post('invites/accept')

--- a/apps/api/src/families/families.service.ts
+++ b/apps/api/src/families/families.service.ts
@@ -13,6 +13,7 @@ import {
 } from '../auth/auth.utils';
 import { PrismaService } from '../prisma/prisma.service';
 import { AcceptFamilyInviteDto } from './dto/accept-family-invite.dto';
+import { AddFamilyMemberDto } from './dto/add-family-member.dto';
 import { CreateFamilyDto } from './dto/create-family.dto';
 
 const FAMILY_MEMBER_SELECT = {
@@ -353,6 +354,45 @@ export class FamiliesService {
     });
 
     return { success: true };
+  }
+
+  async addMember(
+    currentUserId: number,
+    familyId: number,
+    dto: AddFamilyMemberDto,
+  ) {
+    await this.assertFamilyAdmin(currentUserId, familyId);
+
+    const targetUser = await this.prisma.user.findUnique({
+      where: { id: dto.userId },
+      select: { id: true },
+    });
+    if (!targetUser) {
+      throw new NotFoundException('User not found');
+    }
+
+    const existing = await this.prisma.familyMembership.findUnique({
+      where: { userId_familyId: { userId: dto.userId, familyId } },
+      select: { id: true },
+    });
+    if (existing) {
+      throw new ConflictException('User is already a member of this family');
+    }
+
+    await this.prisma.familyMembership.create({
+      data: { userId: dto.userId, familyId, role: 'member' },
+    });
+
+    const family = await this.prisma.family.findUnique({
+      where: { id: familyId },
+      include: FAMILY_INCLUDE,
+    });
+
+    if (!family) {
+      throw new NotFoundException('Family not found');
+    }
+
+    return this.mapFamilySummary(family, currentUserId);
   }
 
   async assertSharedFamily(currentUserId: number, ownerId: number) {

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { AuthGuard } from '../auth/auth.guard';
+import { CurrentUser } from '../auth/current-user.decorator';
+import type { AuthenticatedUser } from '../auth/auth.types';
+import { UsersService } from './users.service';
+
+@Controller('users')
+@UseGuards(AuthGuard)
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Get('search')
+  searchUsers(
+    @CurrentUser() user: AuthenticatedUser,
+    @Query('q') q: string = '',
+  ) {
+    return this.usersService.searchUsers(user.id, q);
+  }
+}

--- a/apps/api/src/users/users.module.ts
+++ b/apps/api/src/users/users.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { UsersController } from './users.controller';
+import { UsersService } from './users.service';
+
+@Module({
+  controllers: [UsersController],
+  providers: [UsersService],
+})
+export class UsersModule {}

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class UsersService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async searchUsers(currentUserId: number, query: string) {
+    const trimmed = query.trim();
+    if (!trimmed) return [];
+
+    return this.prisma.user.findMany({
+      where: {
+        id: { not: currentUserId },
+        OR: [
+          { name: { contains: trimmed } },
+          { email: { contains: trimmed } },
+        ],
+      },
+      select: { id: true, name: true, email: true },
+      take: 10,
+    });
+  }
+}

--- a/apps/api/src/wishlist-items/dto/update-wishlist-item.dto.ts
+++ b/apps/api/src/wishlist-items/dto/update-wishlist-item.dto.ts
@@ -1,4 +1,4 @@
-import { IsNumber, IsOptional, IsString, IsUrl } from 'class-validator';
+import { IsNumber, IsOptional, IsString, IsUrl, ValidateIf } from 'class-validator';
 import { Type, Transform } from 'class-transformer';
 import type { UpdateWishlistItemInput } from '@wishlist/shared';
 
@@ -11,11 +11,13 @@ export class UpdateWishlistItemDto implements UpdateWishlistItemInput {
   name?: string;
 
   @IsOptional()
+  @ValidateIf((o: UpdateWishlistItemDto) => o.url !== null)
   @IsUrl()
-  url?: string;
+  url?: string | null;
 
   @IsOptional()
+  @ValidateIf((o: UpdateWishlistItemDto) => o.price !== null)
   @Type(() => Number)
   @IsNumber()
-  price?: number;
+  price?: number | null;
 }

--- a/apps/api/src/wishlist-items/dto/update-wishlist-item.dto.ts
+++ b/apps/api/src/wishlist-items/dto/update-wishlist-item.dto.ts
@@ -1,0 +1,21 @@
+import { IsNumber, IsOptional, IsString, IsUrl } from 'class-validator';
+import { Type, Transform } from 'class-transformer';
+import type { UpdateWishlistItemInput } from '@wishlist/shared';
+
+export class UpdateWishlistItemDto implements UpdateWishlistItemInput {
+  @IsOptional()
+  @Transform(({ value }: { value: unknown }) =>
+    typeof value === 'string' ? value.trim() : value,
+  )
+  @IsString()
+  name?: string;
+
+  @IsOptional()
+  @IsUrl()
+  url?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  price?: number;
+}

--- a/apps/api/src/wishlist-items/wishlist-items.controller.ts
+++ b/apps/api/src/wishlist-items/wishlist-items.controller.ts
@@ -1,11 +1,13 @@
 import {
   BadRequestException,
+  Body,
   Controller,
   Delete,
   Get,
   HttpCode,
   Param,
   ParseIntPipe,
+  Patch,
   Query,
   UseGuards,
 } from '@nestjs/common';
@@ -13,6 +15,7 @@ import { CurrentUser } from '../auth/current-user.decorator';
 import { AuthGuard } from '../auth/auth.guard';
 import type { AuthenticatedUser } from '../auth/auth.types';
 import { WishlistItemsService } from './wishlist-items.service';
+import { UpdateWishlistItemDto } from './dto/update-wishlist-item.dto';
 
 @Controller('wishlist-items')
 @UseGuards(AuthGuard)
@@ -45,6 +48,15 @@ export class WishlistItemsController {
       limitNum,
       userIdNum,
     );
+  }
+
+  @Patch(':id')
+  updateWishlistItem(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: UpdateWishlistItemDto,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.wishlistItemsService.updateWishlistItem(id, dto, user.id);
   }
 
   @Delete(':id')

--- a/apps/api/src/wishlist-items/wishlist-items.service.ts
+++ b/apps/api/src/wishlist-items/wishlist-items.service.ts
@@ -6,6 +6,7 @@ import {
 import { Prisma } from '@prisma/client';
 import { FamiliesService } from '../families/families.service';
 import { PrismaService } from '../prisma/prisma.service';
+import { UpdateWishlistItemDto } from './dto/update-wishlist-item.dto';
 
 @Injectable()
 export class WishlistItemsService {
@@ -112,6 +113,45 @@ export class WishlistItemsService {
         totalPages,
       },
     };
+  }
+
+  async updateWishlistItem(
+    id: number,
+    dto: UpdateWishlistItemDto,
+    currentUserId: number,
+  ) {
+    const item = await this.prisma.wishlistItem.findUnique({
+      where: { id },
+      select: { id: true, wishlist: { select: { userId: true } } },
+    });
+
+    if (!item) {
+      throw new NotFoundException(`WishlistItem ${id} not found`);
+    }
+
+    if (item.wishlist.userId !== currentUserId) {
+      throw new ForbiddenException(
+        'You can only edit items in your own wishlist',
+      );
+    }
+
+    return this.prisma.wishlistItem.update({
+      where: { id },
+      data: {
+        ...(dto.name !== undefined && { name: dto.name.trim() }),
+        ...(dto.url !== undefined && { url: dto.url }),
+        ...(dto.price !== undefined && { price: dto.price }),
+      },
+      select: {
+        id: true,
+        name: true,
+        url: true,
+        price: true,
+        createdAt: true,
+        updatedAt: true,
+        wishlistId: true,
+      },
+    });
   }
 
   async deleteWishlistItem(id: number, currentUserId: number) {

--- a/apps/api/src/wishlists/dto/create-wishlist.dto.ts
+++ b/apps/api/src/wishlists/dto/create-wishlist.dto.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+import { Transform } from 'class-transformer';
+
+export class CreateWishlistDto {
+  @Transform(({ value }: { value: unknown }) =>
+    typeof value === 'string' ? value.trim() : value,
+  )
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+}

--- a/apps/api/src/wishlists/wishlists.controller.ts
+++ b/apps/api/src/wishlists/wishlists.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Get,
   Param,
   ParseIntPipe,
   Post,
@@ -8,6 +9,7 @@ import {
 } from '@nestjs/common';
 import { WishlistsService } from './wishlists.service';
 import { CreateWishlistItemDto } from '../wishlist-items/dto/create-wishlist-item.dto';
+import { CreateWishlistDto } from './dto/create-wishlist.dto';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { AuthGuard } from '../auth/auth.guard';
 import type { AuthenticatedUser } from '../auth/auth.types';
@@ -16,6 +18,20 @@ import type { AuthenticatedUser } from '../auth/auth.types';
 @UseGuards(AuthGuard)
 export class WishlistsController {
   constructor(private readonly wishlistsService: WishlistsService) {}
+
+  @Post()
+  createWishlist(
+    @Body() dto: CreateWishlistDto,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.wishlistsService.createWishlist(dto, user.id);
+  }
+
+  @Get('mine')
+  listMyWishlists(@CurrentUser() user: AuthenticatedUser) {
+    return this.wishlistsService.listMyWishlists(user.id);
+  }
+
   @Post(':wishlistId/items')
   createWishlistItem(
     @Param('wishlistId', ParseIntPipe) wishlistId: number,

--- a/apps/api/src/wishlists/wishlists.service.ts
+++ b/apps/api/src/wishlists/wishlists.service.ts
@@ -5,10 +5,45 @@ import {
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateWishlistItemDto } from '../wishlist-items/dto/create-wishlist-item.dto';
+import { CreateWishlistDto } from './dto/create-wishlist.dto';
 
 @Injectable()
 export class WishlistsService {
   constructor(private prisma: PrismaService) {}
+
+  async createWishlist(dto: CreateWishlistDto, currentUserId: number) {
+    const wishlist = await this.prisma.wishlist.create({
+      data: {
+        title: dto.title,
+        userId: currentUserId,
+      },
+      select: {
+        id: true,
+        title: true,
+        userId: true,
+        createdAt: true,
+        updatedAt: true,
+        _count: { select: { items: true } },
+      },
+    });
+    return { ...wishlist, itemCount: wishlist._count.items };
+  }
+
+  async listMyWishlists(currentUserId: number) {
+    const wishlists = await this.prisma.wishlist.findMany({
+      where: { userId: currentUserId },
+      orderBy: { createdAt: 'desc' },
+      select: {
+        id: true,
+        title: true,
+        userId: true,
+        createdAt: true,
+        updatedAt: true,
+        _count: { select: { items: true } },
+      },
+    });
+    return wishlists.map((w) => ({ ...w, itemCount: w._count.items }));
+  }
   async createWishlistItem(
     wishlistId: number,
     dto: CreateWishlistItemDto,

--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -374,6 +374,76 @@
   font-size: 0.875rem;
 }
 
+/* ---- UserSearchPanel ---- */
+.user-search-panel {
+  margin: 1.5rem 0;
+  padding: 1.25rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 18px;
+  background: #f8fafc;
+}
+
+.user-search-panel h3 {
+  margin: 0 0 0.25rem;
+}
+
+.user-search-form {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.user-search-form input {
+  flex: 1;
+  border: 1px solid #cbd5e1;
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+}
+
+.user-search-form .secondary-action {
+  white-space: nowrap;
+  padding: 0.75rem 1rem;
+}
+
+.user-search-results {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.user-search-result-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  padding: 0.75rem 1rem;
+  background: #fff;
+  flex-wrap: wrap;
+}
+
+.user-search-result-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.user-search-result-actions select {
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.9rem;
+}
+
+.user-search-result-actions .secondary-action {
+  padding: 0.6rem 0.75rem;
+  font-size: 0.875rem;
+}
+
 /* ---- FollowUserRow ---- */
 .follow-user-row {
   display: flex;

--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -3,12 +3,19 @@
   min-height: 100vh;
   width: 100%;
   box-sizing: border-box;
-  padding: 3rem 1.5rem;
+  padding: 1.5rem 1.5rem 5rem; /* bottom padding for fixed tab bar on mobile */
 }
 
 .app-shell {
   margin: 0 auto;
-  max-width: 1200px;
+  max-width: 860px;
+}
+
+@media (min-width: 768px) {
+  .app-shell,
+  .auth-shell {
+    padding: 3rem 2rem 3rem;
+  }
 }
 
 .auth-shell {
@@ -265,12 +272,162 @@
   font-weight: 600;
 }
 
-@media (min-width: 960px) {
-  .content-grid {
-    grid-template-columns: minmax(320px, 380px) minmax(0, 1fr);
-    align-items: start;
+/* ---- Stats row ---- */
+.stats-row {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+/* ---- Bottom tabs ---- */
+.bottom-tabs {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  border-top: 1px solid #e2e8f0;
+  background: rgba(255, 255, 255, 0.97);
+  backdrop-filter: blur(8px);
+  z-index: 100;
+}
+
+.tab-button {
+  flex: 1;
+  padding: 0.85rem 0.5rem;
+  border: none;
+  background: transparent;
+  color: #64748b;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  border-top: 2px solid transparent;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.tab-button--active {
+  color: #2563eb;
+  border-top-color: #2563eb;
+}
+
+.tab-content {
+  margin-top: 1rem;
+}
+
+/* ---- Wishlist list (my wishlists summary) ---- */
+.wishlist-list {
+  display: grid;
+  gap: 0.5rem;
+  margin: 1rem 0;
+}
+
+.wishlist-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border: 1px solid #dbeafe;
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  background: #eff6ff;
+}
+
+/* ---- Card (WishlistItemCard) ---- */
+.card {
+  border-radius: 18px;
+  border: 1px solid #e2e8f0;
+  background: #fff;
+  padding: 1rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.card-body {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.card-title {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.card-link {
+  color: #2563eb;
+  font-size: 0.9rem;
+}
+
+.card-price {
+  margin: 0;
+  font-weight: 600;
+  color: #166534;
+}
+
+.card-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.card-actions .secondary-action {
+  flex: 1;
+  padding: 0.6rem 0.75rem;
+  font-size: 0.875rem;
+}
+
+/* ---- FollowUserRow ---- */
+.follow-user-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid #f1f5f9;
+}
+
+.follow-user-row:last-child {
+  border-bottom: none;
+}
+
+.follow-users-section {
+  margin-top: 1.5rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid #e2e8f0;
+}
+
+/* ---- Stacked form inputs ---- */
+.stacked-form input,
+.stacked-form select {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid #cbd5e1;
+  border-radius: 12px;
+  padding: 0.85rem 1rem;
+  font-size: 1rem;
+}
+
+/* ---- Desktop: tabs become a top row instead of fixed bottom bar ---- */
+@media (min-width: 768px) {
+  .bottom-tabs {
+    position: static;
+    border-top: none;
+    border-bottom: 1px solid #e2e8f0;
+    background: transparent;
+    backdrop-filter: none;
+    margin-bottom: 0;
   }
 
+  .tab-button {
+    border-top: none;
+    border-bottom: 2px solid transparent;
+  }
+
+  .tab-button--active {
+    border-top-color: transparent;
+    border-bottom-color: #2563eb;
+  }
+}
+
+@media (min-width: 960px) {
   .family-forms {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -65,6 +65,9 @@ function App() {
   const [meta, setMeta] = useState<PaginationMeta>();
   const [limit, setLimit] = useState(DEFAULT_LIMIT);
 
+  // My items (fetched independently from the shared feed)
+  const [myItems, setMyItems] = useState<WishlistItemResponse[]>([]);
+
   // My wishlists state
   const [myWishlists, setMyWishlists] = useState<WishlistSummary[]>([]);
   const [createWishlistLoading, setCreateWishlistLoading] = useState(false);
@@ -165,6 +168,16 @@ function App() {
     }
   }, [currentPage, currentUser, limit]);
 
+  const fetchMyItems = useCallback(async () => {
+    if (!currentUser) return;
+    try {
+      const res = await getWishlistItems(1, 100, currentUser.id);
+      setMyItems(res.data);
+    } catch {
+      // non-critical — My Wishlist tab shows empty list
+    }
+  }, [currentUser]);
+
   const fetchMyWishlists = useCallback(async () => {
     if (!currentUser) return;
     try {
@@ -184,7 +197,8 @@ function App() {
     void fetchData();
     void fetchFamilies();
     void fetchMyWishlists();
-  }, [currentUser, fetchData, fetchFamilies, fetchMyWishlists]);
+    void fetchMyItems();
+  }, [currentUser, fetchData, fetchFamilies, fetchMyWishlists, fetchMyItems]);
 
   useEffect(() => {
     if (!pendingInviteToken) return;
@@ -236,24 +250,24 @@ function App() {
     async (id: number) => {
       try {
         await deleteWishListItem(id);
-        await fetchData();
+        await Promise.all([fetchData(), fetchMyItems()]);
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to delete wishlist item');
       }
     },
-    [fetchData],
+    [fetchData, fetchMyItems],
   );
 
   const handleEditItem = useCallback(
     async (id: number, data: UpdateWishlistItemInput) => {
       try {
         await updateWishlistItem(id, data);
-        await fetchData();
+        await Promise.all([fetchData(), fetchMyItems()]);
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to update wishlist item');
       }
     },
-    [fetchData],
+    [fetchData, fetchMyItems],
   );
 
   const handleSearchSubmit = () => {
@@ -267,8 +281,6 @@ function App() {
         item.name.toLowerCase().includes(searchUserName.toLowerCase()) ||
         item.wishlistTitle.toLowerCase().includes(searchUserName.toLowerCase()),
   );
-
-  const ownItems = wishlistItems.filter((item) => item.ownerId === currentUser?.id);
 
   const resetAuthFeedback = () => {
     setAuthError(null);
@@ -333,6 +345,7 @@ function App() {
     } finally {
       setCurrentUser(null);
       setWishlistItems([]);
+      setMyItems([]);
       setMeta(undefined);
       setMyWishlists([]);
       setFamilies([]);
@@ -451,6 +464,7 @@ function App() {
       await createWishlistItem(resolvedId, data);
       await fetchData();
       await fetchMyWishlists();
+      await fetchMyItems();
     } catch (err) {
       setAddItemError(err instanceof Error ? err.message : 'Failed to add item');
     } finally {
@@ -596,7 +610,7 @@ function App() {
       .map((member) => ({ member, familyName: family.name })),
   );
 
-  const myItemCount = ownItems.length;
+  const myItemCount = myItems.length;
 
   return (
     <div className="app-shell">
@@ -657,19 +671,19 @@ function App() {
               </div>
             )}
 
-            {ownItems.length > 0 && (
+            {myItems.length > 0 && (
               <div className="panel-header" style={{ marginTop: '1.5rem' }}>
                 <h2>My items</h2>
               </div>
             )}
-            {ownItems.length === 0 ? (
+            {myItems.length === 0 ? (
               <div className="empty-state">
                 <h3>No items yet</h3>
                 <p>Add items to your wishlist above.</p>
               </div>
             ) : (
               <div className="wishlist-stack">
-                {ownItems.map((item) => (
+                {myItems.map((item) => (
                   <WishlistItemCard
                     key={item.id}
                     {...item}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -10,14 +10,26 @@ import {
   getFamilyInvites,
   revokeFamilyInvite,
 } from './api/families';
-import { deleteWishListItem, getWishlistItems } from './api/wishlistItems';
-import { Card, DropDown, PaginationButtons, UserSearch } from './components/index';
+import { deleteWishListItem, getWishlistItems, updateWishlistItem } from './api/wishlistItems';
+import { createWishlist, createWishlistItem, getMyWishlists } from './api/wishlists';
+import AddItemForm from './components/AddItemForm';
+import AppHeader from './components/AppHeader';
+import BottomTabs from './components/BottomTabs';
+import type { AppTab } from './components/BottomTabs';
+import CreateWishlistForm from './components/CreateWishlistForm';
+import FamiliesPanel from './components/FamiliesPanel';
+import FollowUserRow from './components/FollowUserRow';
+import StatsRow from './components/StatsRow';
+import WishlistItemCard from './components/WishlistItemCard';
+import { DropDown, PaginationButtons, UserSearch } from './components/index';
 import type {
   AuthUser,
   FamilyInviteSummary,
   FamilySummary,
   PaginationMeta,
+  UpdateWishlistItemInput,
   WishlistItemResponse,
+  WishlistSummary,
 } from './types/wishlist';
 
 const DEFAULT_LIMIT = 10;
@@ -41,6 +53,8 @@ function App() {
     token: string;
     expiresAt?: string;
   } | null>(null);
+
+  // Feed state
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [wishlistItems, setWishlistItems] = useState<WishlistItemResponse[]>([]);
@@ -49,30 +63,36 @@ function App() {
   const [currentPage, setCurrentPage] = useState(1);
   const [meta, setMeta] = useState<PaginationMeta>();
   const [limit, setLimit] = useState(DEFAULT_LIMIT);
+
+  // My wishlists state
+  const [myWishlists, setMyWishlists] = useState<WishlistSummary[]>([]);
+  const [createWishlistLoading, setCreateWishlistLoading] = useState(false);
+  const [createWishlistError, setCreateWishlistError] = useState<string | null>(null);
+  const [addItemLoading, setAddItemLoading] = useState(false);
+  const [addItemError, setAddItemError] = useState<string | null>(null);
+
+  // Family state
   const [families, setFamilies] = useState<FamilySummary[]>([]);
   const [familyInvites, setFamilyInvites] = useState<Record<number, FamilyInviteSummary[]>>({});
   const [latestInviteLinks, setLatestInviteLinks] = useState<Record<number, string>>({});
   const [familyLoading, setFamilyLoading] = useState(false);
   const [familyError, setFamilyError] = useState<string | null>(null);
   const [familyNotice, setFamilyNotice] = useState<string | null>(null);
-  const [familyForm, setFamilyForm] = useState({
-    createName: '',
-  });
-  const [pendingInviteToken, setPendingInviteToken] = useState<string | null>(() => {
-    if (typeof window === 'undefined') {
-      return null;
-    }
+  const [familyForm, setFamilyForm] = useState({ createName: '' });
+  const [inviteActionFamilyId, setInviteActionFamilyId] = useState<number | null>(null);
 
+  // Invite acceptance state
+  const [pendingInviteToken, setPendingInviteToken] = useState<string | null>(() => {
+    if (typeof window === 'undefined') return null;
     return new URLSearchParams(window.location.search).get('inviteToken');
   });
   const [inviteAcceptanceLoading, setInviteAcceptanceLoading] = useState(false);
-  const [inviteActionFamilyId, setInviteActionFamilyId] = useState<number | null>(null);
+
+  // Tab navigation
+  const [activeTab, setActiveTab] = useState<AppTab>('feed');
 
   const clearInviteTokenFromUrl = useCallback(() => {
-    if (typeof window === 'undefined') {
-      return;
-    }
-
+    if (typeof window === 'undefined') return;
     window.history.replaceState({}, '', window.location.pathname);
   }, []);
 
@@ -91,19 +111,16 @@ function App() {
 
   const fetchFamilyInvites = useCallback(async (familyList: FamilySummary[]) => {
     const adminFamilies = familyList.filter((family) => family.currentUserRole === 'admin');
-
     if (adminFamilies.length === 0) {
       setFamilyInvites({});
       return;
     }
-
     const entries = await Promise.all(
       adminFamilies.map(async (family) => {
         const invites = await getFamilyInvites(family.id);
         return [family.id, invites] as const;
       }),
     );
-
     setFamilyInvites(Object.fromEntries(entries));
   }, []);
 
@@ -113,7 +130,6 @@ function App() {
       setFamilyInvites({});
       return;
     }
-
     setFamilyLoading(true);
     try {
       const response = await getFamilies();
@@ -128,10 +144,7 @@ function App() {
   }, [currentUser, fetchFamilyInvites]);
 
   const fetchData = useCallback(async () => {
-    if (!currentUser) {
-      return;
-    }
-
+    if (!currentUser) return;
     setLoading(true);
     setError(null);
     try {
@@ -147,38 +160,39 @@ function App() {
     }
   }, [currentPage, currentUser, limit]);
 
+  const fetchMyWishlists = useCallback(async () => {
+    if (!currentUser) return;
+    try {
+      const data = await getMyWishlists();
+      setMyWishlists(data);
+    } catch {
+      // non-critical — user sees empty list
+    }
+  }, [currentUser]);
+
   useEffect(() => {
     void bootstrapUser();
   }, [bootstrapUser]);
 
   useEffect(() => {
-    if (!currentUser) {
-      return;
-    }
-
+    if (!currentUser) return;
     void fetchData();
     void fetchFamilies();
-  }, [currentUser, fetchData, fetchFamilies]);
+    void fetchMyWishlists();
+  }, [currentUser, fetchData, fetchFamilies, fetchMyWishlists]);
 
   useEffect(() => {
-    if (!pendingInviteToken) {
-      return;
-    }
-
+    if (!pendingInviteToken) return;
     if (!currentUser) {
       setAuthNotice('Sign in to accept your family invite link.');
       setAuthMode('login');
       return;
     }
-
-    if (inviteAcceptanceLoading) {
-      return;
-    }
+    if (inviteAcceptanceLoading) return;
 
     const acceptInvite = async () => {
       setInviteAcceptanceLoading(true);
       setFamilyError(null);
-
       try {
         const family = await acceptFamilyInvite(pendingInviteToken);
         setFamilyNotice(`You joined ${family.name}.`);
@@ -225,6 +239,18 @@ function App() {
     [fetchData],
   );
 
+  const handleEditItem = useCallback(
+    async (id: number, data: UpdateWishlistItemInput) => {
+      try {
+        await updateWishlistItem(id, data);
+        await fetchData();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to update wishlist item');
+      }
+    },
+    [fetchData],
+  );
+
   const handleSearchSubmit = () => {
     setSearchUserName(inputUserName.trim());
   };
@@ -237,6 +263,8 @@ function App() {
         item.wishlistTitle.toLowerCase().includes(searchUserName.toLowerCase()),
   );
 
+  const ownItems = wishlistItems.filter((item) => item.ownerId === currentUser?.id);
+
   const resetAuthFeedback = () => {
     setAuthError(null);
     setAuthNotice(null);
@@ -244,9 +272,7 @@ function App() {
 
   const handleAuthModeChange = (mode: AuthMode) => {
     resetAuthFeedback();
-    if (mode !== 'reset') {
-      setDevResetToken(null);
-    }
+    if (mode !== 'reset') setDevResetToken(null);
     setAuthMode(mode);
   };
 
@@ -258,44 +284,19 @@ function App() {
       const normalizedEmail = authForm.email.trim().toLowerCase();
 
       if (authMode === 'register') {
-        await register({
-          name: authForm.name.trim(),
-          email: normalizedEmail,
-          password: authForm.password,
-        });
-
-        const response = await login({
-          email: normalizedEmail,
-          password: authForm.password,
-        });
-
+        await register({ name: authForm.name.trim(), email: normalizedEmail, password: authForm.password });
+        const response = await login({ email: normalizedEmail, password: authForm.password });
         setCurrentUser(response.user);
-        setAuthForm({
-          name: '',
-          email: '',
-          password: '',
-          resetToken: '',
-          newPassword: '',
-        });
+        setAuthForm({ name: '', email: '', password: '', resetToken: '', newPassword: '' });
         setCurrentPage(1);
         setError(null);
         return;
       }
 
       if (authMode === 'login') {
-        const response = await login({
-          email: normalizedEmail,
-          password: authForm.password,
-        });
-
+        const response = await login({ email: normalizedEmail, password: authForm.password });
         setCurrentUser(response.user);
-        setAuthForm({
-          name: '',
-          email: '',
-          password: '',
-          resetToken: '',
-          newPassword: '',
-        });
+        setAuthForm({ name: '', email: '', password: '', resetToken: '', newPassword: '' });
         setCurrentPage(1);
         setError(null);
         return;
@@ -305,29 +306,15 @@ function App() {
         const response = await forgotPassword(normalizedEmail);
         setAuthNotice(response.message);
         if (response.resetToken) {
-          setDevResetToken({
-            token: response.resetToken,
-            expiresAt: response.expiresAt,
-          });
-          setAuthForm((current) => ({
-            ...current,
-            resetToken: response.resetToken ?? '',
-          }));
+          setDevResetToken({ token: response.resetToken, expiresAt: response.expiresAt });
+          setAuthForm((current) => ({ ...current, resetToken: response.resetToken ?? '' }));
         }
         return;
       }
 
-      const response = await resetPassword({
-        token: authForm.resetToken.trim(),
-        password: authForm.newPassword,
-      });
+      const response = await resetPassword({ token: authForm.resetToken.trim(), password: authForm.newPassword });
       setAuthNotice(response.message);
-      setAuthForm((current) => ({
-        ...current,
-        password: '',
-        resetToken: '',
-        newPassword: '',
-      }));
+      setAuthForm((current) => ({ ...current, password: '', resetToken: '', newPassword: '' }));
       setDevResetToken(null);
       setAuthMode('login');
     } catch (err) {
@@ -342,6 +329,7 @@ function App() {
       setCurrentUser(null);
       setWishlistItems([]);
       setMeta(undefined);
+      setMyWishlists([]);
       setFamilies([]);
       setFamilyInvites({});
       setLatestInviteLinks({});
@@ -357,7 +345,6 @@ function App() {
     event.preventDefault();
     setFamilyError(null);
     setFamilyNotice(null);
-
     try {
       const family = await createFamily(familyForm.createName.trim());
       setFamilies((current) => [...current, family]);
@@ -374,26 +361,13 @@ function App() {
     setFamilyError(null);
     setFamilyNotice(null);
     setInviteActionFamilyId(familyId);
-
     try {
       const invite = await createFamilyInvite(familyId);
-      setLatestInviteLinks((current) => ({
-        ...current,
-        [familyId]: invite.inviteUrl,
-      }));
+      setLatestInviteLinks((current) => ({ ...current, [familyId]: invite.inviteUrl }));
       setFamilyInvites((current) => ({
         ...current,
         [familyId]: [
-          {
-            id: invite.id,
-            familyId: invite.familyId,
-            createdByUser: invite.createdByUser,
-            expiresAt: invite.expiresAt,
-            usedAt: invite.usedAt,
-            revokedAt: invite.revokedAt,
-            createdAt: invite.createdAt,
-            updatedAt: invite.updatedAt,
-          },
+          { id: invite.id, familyId: invite.familyId, createdByUser: invite.createdByUser, expiresAt: invite.expiresAt, usedAt: invite.usedAt, revokedAt: invite.revokedAt, createdAt: invite.createdAt, updatedAt: invite.updatedAt },
           ...(current[familyId] ?? []),
         ],
       }));
@@ -409,7 +383,6 @@ function App() {
     setFamilyError(null);
     setFamilyNotice(null);
     setInviteActionFamilyId(familyId);
-
     try {
       await revokeFamilyInvite(inviteId);
       setFamilyInvites((current) => ({
@@ -423,6 +396,47 @@ function App() {
       setInviteActionFamilyId(null);
     }
   };
+
+  const handleCreateWishlist = async (title: string) => {
+    setCreateWishlistLoading(true);
+    setCreateWishlistError(null);
+    try {
+      const wishlist = await createWishlist(title);
+      setMyWishlists((prev) => [wishlist, ...prev]);
+    } catch (err) {
+      setCreateWishlistError(err instanceof Error ? err.message : 'Failed to create wishlist');
+    } finally {
+      setCreateWishlistLoading(false);
+    }
+  };
+
+  const handleAddItem = async (
+    wishlistId: number,
+    data: { name: string; url?: string; price?: number },
+  ) => {
+    setAddItemLoading(true);
+    setAddItemError(null);
+    try {
+      await createWishlistItem(wishlistId, data);
+      await fetchData();
+      await fetchMyWishlists();
+    } catch (err) {
+      setAddItemError(err instanceof Error ? err.message : 'Failed to add item');
+    } finally {
+      setAddItemLoading(false);
+    }
+  };
+
+  const handleViewUserWishlist = (userId: number) => {
+    const member = families.flatMap((f) => f.members).find((m) => m.id === userId);
+    if (member) {
+      setInputUserName(member.name);
+      setSearchUserName(member.name);
+    }
+    setActiveTab('feed');
+  };
+
+  // --- Rendering ---
 
   if (authLoading) {
     return <div className="app-shell">Checking your session...</div>;
@@ -445,8 +459,7 @@ function App() {
             {authMode === 'reset' && 'Reset password'}
           </h1>
           <p className="subtle">
-            {authMode === 'login' &&
-              'Sign in to browse family wishlists and manage your own items.'}
+            {authMode === 'login' && 'Sign in to browse family wishlists and manage your own items.'}
             {authMode === 'register' && 'Create an account, then sign in immediately.'}
             {authMode === 'forgot' && 'Request a short-lived reset token for your account.'}
             {authMode === 'reset' && 'Use your reset token to choose a new password.'}
@@ -462,12 +475,7 @@ function App() {
                 type="text"
                 placeholder="Name"
                 value={authForm.name}
-                onChange={(event) =>
-                  setAuthForm((current) => ({
-                    ...current,
-                    name: event.target.value,
-                  }))
-                }
+                onChange={(event) => setAuthForm((current) => ({ ...current, name: event.target.value }))}
               />
             )}
             {(showPasswordField || showForgotField) && (
@@ -475,12 +483,7 @@ function App() {
                 type="email"
                 placeholder="Email"
                 value={authForm.email}
-                onChange={(event) =>
-                  setAuthForm((current) => ({
-                    ...current,
-                    email: event.target.value,
-                  }))
-                }
+                onChange={(event) => setAuthForm((current) => ({ ...current, email: event.target.value }))}
               />
             )}
             {showPasswordField && (
@@ -488,12 +491,7 @@ function App() {
                 type="password"
                 placeholder="Password"
                 value={authForm.password}
-                onChange={(event) =>
-                  setAuthForm((current) => ({
-                    ...current,
-                    password: event.target.value,
-                  }))
-                }
+                onChange={(event) => setAuthForm((current) => ({ ...current, password: event.target.value }))}
               />
             )}
             {showResetFields && (
@@ -502,23 +500,13 @@ function App() {
                   type="text"
                   placeholder="Reset token"
                   value={authForm.resetToken}
-                  onChange={(event) =>
-                    setAuthForm((current) => ({
-                      ...current,
-                      resetToken: event.target.value,
-                    }))
-                  }
+                  onChange={(event) => setAuthForm((current) => ({ ...current, resetToken: event.target.value }))}
                 />
                 <input
                   type="password"
                   placeholder="New password"
                   value={authForm.newPassword}
-                  onChange={(event) =>
-                    setAuthForm((current) => ({
-                      ...current,
-                      newPassword: event.target.value,
-                    }))
-                  }
+                  onChange={(event) => setAuthForm((current) => ({ ...current, newPassword: event.target.value }))}
                 />
               </>
             )}
@@ -546,10 +534,7 @@ function App() {
             )}
             {authMode === 'login' && (
               <>
-                <button
-                  className="secondary-action"
-                  onClick={() => handleAuthModeChange('register')}
-                >
+                <button className="secondary-action" onClick={() => handleAuthModeChange('register')}>
                   Need an account? Register
                 </button>
                 <button className="secondary-action" onClick={() => handleAuthModeChange('forgot')}>
@@ -573,191 +558,182 @@ function App() {
     );
   }
 
+  // Collect all unique family members (excluding current user) with their family name
+  const familyMembers = families.flatMap((family) =>
+    family.members
+      .filter((member) => member.id !== currentUser.id)
+      .map((member) => ({ member, familyName: family.name })),
+  );
+
+  const myItemCount = ownItems.length;
+
   return (
     <div className="app-shell">
-      <div className="app-header">
-        <div>
-          <p className="eyebrow">Wishlist</p>
-          <h1>Wishlists</h1>
-          <p className="subtle">Signed in as {currentUser.name}</p>
-        </div>
-        <button className="secondary-action" onClick={() => void handleLogout()}>
-          Sign out
-        </button>
-      </div>
+      <AppHeader userName={currentUser.name} onSignOut={() => void handleLogout()} />
+      <StatsRow
+        myItemCount={myItemCount}
+        myWishlistCount={myWishlists.length}
+        familyCount={families.length}
+      />
+      <BottomTabs activeTab={activeTab} onChange={setActiveTab} />
 
-      <div className="content-grid">
-        <section className="panel">
-          <div className="panel-header">
-            <div>
-              <h2>Your families</h2>
-              <p className="subtle">
-                Wishlist visibility is limited to people who share at least one family with you.
-              </p>
-            </div>
-            {(familyLoading || inviteAcceptanceLoading) && <span className="pill">Refreshing</span>}
-          </div>
-          <div className="family-forms family-forms-single">
-            <form className="stacked-form" onSubmit={(event) => void handleCreateFamily(event)}>
-              <label htmlFor="create-family-name">Create family</label>
-              <input
-                id="create-family-name"
-                type="text"
-                placeholder="Family name"
-                value={familyForm.createName}
-                onChange={(event) =>
-                  setFamilyForm((current) => ({
-                    ...current,
-                    createName: event.target.value,
-                  }))
-                }
-              />
-              <button type="submit" className="primary-action">
-                Create family
-              </button>
-            </form>
-          </div>
-          {familyError && <p className="form-error">{familyError}</p>}
-          {familyNotice && <p className="form-notice">{familyNotice}</p>}
-          <div className="family-list">
-            {families.length === 0 ? (
-              <div className="empty-state">
-                <h3>No families yet</h3>
-                <p>Create one to start sharing invite links with relatives.</p>
+      <div className="tab-content">
+        {activeTab === 'wishlist' && (
+          <div className="panel">
+            <div className="panel-header">
+              <div>
+                <h2>My Wishlist</h2>
+                <p className="subtle">Create wishlists and manage your items.</p>
               </div>
-            ) : (
-              families.map((family) => (
-                <article className="family-card" key={family.id}>
-                  <div className="family-card-header">
-                    <div>
-                      <h3>{family.name}</h3>
-                      <div className="family-card-meta">
-                        <span className="pill">{family.memberCount} members</span>
-                        <span className="role-pill">{family.currentUserRole}</span>
-                      </div>
-                    </div>
+            </div>
+
+            <CreateWishlistForm
+              onSubmit={handleCreateWishlist}
+              loading={createWishlistLoading}
+              error={createWishlistError}
+            />
+
+            {myWishlists.length > 0 && (
+              <div className="wishlist-list">
+                {myWishlists.map((wl) => (
+                  <div className="wishlist-row" key={wl.id}>
+                    <strong>{wl.title}</strong>
+                    <span className="pill">{wl.itemCount} {wl.itemCount === 1 ? 'item' : 'items'}</span>
                   </div>
-                  <ul className="family-members">
-                    {family.members.map((member) => (
-                      <li key={member.id}>
-                        <strong>{member.name}</strong>
-                        <span>{member.email}</span>
-                      </li>
-                    ))}
-                  </ul>
-                  {family.currentUserRole === 'admin' && (
-                    <div className="invite-panel">
-                      <div className="invite-panel-header">
-                        <h4>Invite links</h4>
-                        <button
-                          className="secondary-action"
-                          onClick={() => void handleCreateInvite(family.id)}
-                        >
-                          {inviteActionFamilyId === family.id ? 'Working...' : 'Create invite link'}
-                        </button>
-                      </div>
-                      {latestInviteLinks[family.id] && (
-                        <div className="invite-link-card">
-                          <label htmlFor={`invite-link-${family.id}`}>Latest invite link</label>
-                          <input
-                            id={`invite-link-${family.id}`}
-                            type="text"
-                            readOnly
-                            value={latestInviteLinks[family.id]}
-                          />
-                        </div>
-                      )}
-                      {(familyInvites[family.id] ?? []).length === 0 ? (
-                        <p className="subtle">No active invites.</p>
-                      ) : (
-                        <ul className="invite-list">
-                          {(familyInvites[family.id] ?? []).map((invite) => (
-                            <li key={invite.id}>
-                              <div>
-                                <strong>
-                                  Expires {new Date(invite.expiresAt).toLocaleString()}
-                                </strong>
-                                <p className="subtle">Created by {invite.createdByUser.name}</p>
-                              </div>
-                              <button
-                                className="secondary-action"
-                                onClick={() => void handleRevokeInvite(family.id, invite.id)}
-                              >
-                                Revoke
-                              </button>
-                            </li>
-                          ))}
-                        </ul>
-                      )}
-                    </div>
-                  )}
-                </article>
-              ))
+                ))}
+              </div>
             )}
-          </div>
-        </section>
 
-        <section className="panel">
-          <div className="panel-header">
-            <div>
-              <h2>Shared wishlist feed</h2>
-              <p className="subtle">
-                The feed shows your own items plus wishlists from users who share a family with you.
-              </p>
-            </div>
-          </div>
-          <UserSearch
-            onSubmit={handleSearchSubmit}
-            value={inputUserName}
-            onChange={setInputUserName}
-          />
-          {loading && <h2>Loading...</h2>}
-          {error ? (
-            <div className="empty-state">
-              <h3>{error}</h3>
-            </div>
-          ) : filteredItems.length === 0 ? (
-            <div className="empty-state">
-              <h3>No visible wishlist items</h3>
-              <p>
-                {families.length === 0
-                  ? 'You can only see your own items until you create or join a family.'
-                  : 'No items match your current family access and search filters.'}
-              </p>
-            </div>
-          ) : (
-            <>
-              <div className="wishlist-stack">
-                {filteredItems.map((item) => (
-                  <Card
-                    {...item}
-                    key={item.id}
-                    onDelete={(id) => {
-                      if (item.ownerId !== currentUser.id) {
-                        setError('You can only delete items from your own wishlist.');
-                        return;
-                      }
+            <AddItemForm
+              wishlists={myWishlists}
+              onSubmit={handleAddItem}
+              loading={addItemLoading}
+              error={addItemError}
+            />
 
-                      void onDeleteItem(id);
-                    }}
+            {familyMembers.length > 0 && (
+              <div className="follow-users-section">
+                <h3>Family members</h3>
+                <p className="subtle">Jump to a family member's items in the feed.</p>
+                {familyMembers.map(({ member, familyName }) => (
+                  <FollowUserRow
+                    key={`${familyName}-${member.id}`}
+                    member={member}
+                    familyName={familyName}
+                    onViewWishlist={handleViewUserWishlist}
                   />
                 ))}
               </div>
-              <PaginationButtons
-                handleBackPage={handleBackPage}
-                handleNextPage={handleNextPage}
-                currentPage={currentPage}
-                totalPages={meta?.totalPages}
-              />
-              <DropDown
-                limit={limit}
-                setLimit={setLimit}
-                setCurrentPage={setCurrentPage}
-                totalItems={meta?.total}
-              />
-            </>
-          )}
-        </section>
+            )}
+
+            {ownItems.length > 0 && (
+              <div className="panel-header" style={{ marginTop: '1.5rem' }}>
+                <h2>My items</h2>
+              </div>
+            )}
+            {ownItems.length === 0 ? (
+              <div className="empty-state">
+                <h3>No items yet</h3>
+                <p>Add items to your wishlist above.</p>
+              </div>
+            ) : (
+              <div className="wishlist-stack">
+                {ownItems.map((item) => (
+                  <WishlistItemCard
+                    key={item.id}
+                    {...item}
+                    isOwner={true}
+                    onDelete={(id) => void onDeleteItem(id)}
+                    onEdit={handleEditItem}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {activeTab === 'feed' && (
+          <section className="panel">
+            <div className="panel-header">
+              <div>
+                <h2>Shared wishlist feed</h2>
+                <p className="subtle">
+                  The feed shows your own items plus wishlists from users who share a family with you.
+                </p>
+              </div>
+            </div>
+            <UserSearch
+              onSubmit={handleSearchSubmit}
+              value={inputUserName}
+              onChange={setInputUserName}
+            />
+            {loading && <h2>Loading...</h2>}
+            {error ? (
+              <div className="empty-state">
+                <h3>{error}</h3>
+              </div>
+            ) : filteredItems.length === 0 ? (
+              <div className="empty-state">
+                <h3>No visible wishlist items</h3>
+                <p>
+                  {families.length === 0
+                    ? 'You can only see your own items until you create or join a family.'
+                    : 'No items match your current family access and search filters.'}
+                </p>
+              </div>
+            ) : (
+              <>
+                <div className="wishlist-stack">
+                  {filteredItems.map((item) => (
+                    <WishlistItemCard
+                      key={item.id}
+                      {...item}
+                      isOwner={item.ownerId === currentUser.id}
+                      onDelete={(id) => {
+                        if (item.ownerId !== currentUser.id) {
+                          setError('You can only delete items from your own wishlist.');
+                          return;
+                        }
+                        void onDeleteItem(id);
+                      }}
+                      onEdit={handleEditItem}
+                    />
+                  ))}
+                </div>
+                <PaginationButtons
+                  handleBackPage={handleBackPage}
+                  handleNextPage={handleNextPage}
+                  currentPage={currentPage}
+                  totalPages={meta?.totalPages}
+                />
+                <DropDown
+                  limit={limit}
+                  setLimit={setLimit}
+                  setCurrentPage={setCurrentPage}
+                  totalItems={meta?.total}
+                />
+              </>
+            )}
+          </section>
+        )}
+
+        {activeTab === 'families' && (
+          <FamiliesPanel
+            families={families}
+            familyInvites={familyInvites}
+            latestInviteLinks={latestInviteLinks}
+            familyLoading={familyLoading}
+            inviteAcceptanceLoading={inviteAcceptanceLoading}
+            inviteActionFamilyId={inviteActionFamilyId}
+            familyError={familyError}
+            familyNotice={familyNotice}
+            familyForm={familyForm}
+            onCreateFamilyFormChange={(value) => setFamilyForm({ createName: value })}
+            onCreateFamily={(event) => void handleCreateFamily(event)}
+            onCreateInvite={(familyId) => void handleCreateInvite(familyId)}
+            onRevokeInvite={(familyId, inviteId) => void handleRevokeInvite(familyId, inviteId)}
+          />
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -12,6 +12,7 @@ import {
 } from './api/families';
 import { deleteWishListItem, getWishlistItems, updateWishlistItem } from './api/wishlistItems';
 import { createWishlist, createWishlistItem, getMyWishlists } from './api/wishlists';
+import { addFamilyMember } from './api/users';
 import AddItemForm from './components/AddItemForm';
 import AppHeader from './components/AppHeader';
 import BottomTabs from './components/BottomTabs';
@@ -87,6 +88,10 @@ function App() {
     return new URLSearchParams(window.location.search).get('inviteToken');
   });
   const [inviteAcceptanceLoading, setInviteAcceptanceLoading] = useState(false);
+
+  // Add member state
+  const [addMemberLoading, setAddMemberLoading] = useState(false);
+  const [addMemberError, setAddMemberError] = useState<string | null>(null);
 
   // Tab navigation
   const [activeTab, setActiveTab] = useState<AppTab>('feed');
@@ -338,6 +343,8 @@ function App() {
       setAuthNotice(null);
       setFamilyError(null);
       setFamilyNotice(null);
+      setAddMemberLoading(false);
+      setAddMemberError(null);
     }
   };
 
@@ -397,6 +404,24 @@ function App() {
     }
   };
 
+  const handleAddMember = useCallback(
+    async (familyId: number, userId: number) => {
+      setAddMemberLoading(true);
+      setAddMemberError(null);
+      try {
+        await addFamilyMember(familyId, userId);
+        setFamilyNotice('Member added successfully.');
+        await fetchFamilies();
+        await fetchData();
+      } catch (err) {
+        setAddMemberError(err instanceof Error ? err.message : 'Failed to add member');
+      } finally {
+        setAddMemberLoading(false);
+      }
+    },
+    [fetchFamilies, fetchData],
+  );
+
   const handleCreateWishlist = async (title: string) => {
     setCreateWishlistLoading(true);
     setCreateWishlistError(null);
@@ -411,13 +436,19 @@ function App() {
   };
 
   const handleAddItem = async (
-    wishlistId: number,
+    wishlistId: number | null,
     data: { name: string; url?: string; price?: number },
   ) => {
     setAddItemLoading(true);
     setAddItemError(null);
     try {
-      await createWishlistItem(wishlistId, data);
+      let resolvedId = wishlistId;
+      if (resolvedId === null) {
+        const newWishlist = await createWishlist('My Wishlist');
+        setMyWishlists((prev) => [newWishlist, ...prev]);
+        resolvedId = newWishlist.id;
+      }
+      await createWishlistItem(resolvedId, data);
       await fetchData();
       await fetchMyWishlists();
     } catch (err) {
@@ -732,6 +763,9 @@ function App() {
             onCreateFamily={(event) => void handleCreateFamily(event)}
             onCreateInvite={(familyId) => void handleCreateInvite(familyId)}
             onRevokeInvite={(familyId, inviteId) => void handleRevokeInvite(familyId, inviteId)}
+            onAddMember={handleAddMember}
+            addMemberLoading={addMemberLoading}
+            addMemberError={addMemberError}
           />
         )}
       </div>

--- a/apps/web/src/api/users.ts
+++ b/apps/web/src/api/users.ts
@@ -1,0 +1,13 @@
+import type { UserSearchResult, FamilySummary } from '../types/wishlist';
+import { apiRequest } from './auth';
+
+export function searchUsers(q: string) {
+  return apiRequest<UserSearchResult[]>(`/api/users/search?q=${encodeURIComponent(q)}`);
+}
+
+export function addFamilyMember(familyId: number, userId: number) {
+  return apiRequest<FamilySummary>(`/api/families/${familyId}/members`, {
+    method: 'POST',
+    body: JSON.stringify({ userId }),
+  });
+}

--- a/apps/web/src/api/wishlistItems.tsx
+++ b/apps/web/src/api/wishlistItems.tsx
@@ -1,4 +1,5 @@
-import type { PaginatedWishlistItems } from '@wishlist/shared';
+import type { PaginatedWishlistItems, UpdateWishlistItemInput, WishlistItem } from '@wishlist/shared';
+import { apiRequest } from './auth';
 
 const BASE_URL = 'http://localhost:3000';
 
@@ -43,4 +44,11 @@ export async function deleteWishListItem(itemId: number) {
     } | null;
     throw new Error(data?.message ?? data?.error ?? `Failed to delete itemId: ${itemId}`);
   }
+}
+
+export function updateWishlistItem(id: number, data: UpdateWishlistItemInput) {
+  return apiRequest<WishlistItem>(`/api/wishlist-items/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify(data),
+  });
 }

--- a/apps/web/src/api/wishlists.ts
+++ b/apps/web/src/api/wishlists.ts
@@ -1,0 +1,23 @@
+import type { WishlistSummary, WishlistItemResponse } from '../types/wishlist';
+import { apiRequest } from './auth';
+
+export function getMyWishlists() {
+  return apiRequest<WishlistSummary[]>('/api/wishlists/mine');
+}
+
+export function createWishlist(title: string) {
+  return apiRequest<WishlistSummary>('/api/wishlists', {
+    method: 'POST',
+    body: JSON.stringify({ title }),
+  });
+}
+
+export function createWishlistItem(
+  wishlistId: number,
+  data: { name: string; url?: string; price?: number },
+) {
+  return apiRequest<WishlistItemResponse>(`/api/wishlists/${wishlistId}/items`, {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+}

--- a/apps/web/src/components/AddItemForm.tsx
+++ b/apps/web/src/components/AddItemForm.tsx
@@ -1,0 +1,92 @@
+import { useState, type FormEvent } from 'react';
+import type { WishlistSummary } from '../types/wishlist';
+
+interface AddItemFormProps {
+  wishlists: WishlistSummary[];
+  onSubmit: (wishlistId: number, data: { name: string; url?: string; price?: number }) => Promise<void>;
+  loading: boolean;
+  error: string | null;
+}
+
+export default function AddItemForm({ wishlists, onSubmit, loading, error }: AddItemFormProps) {
+  const [selectedWishlistId, setSelectedWishlistId] = useState<number | ''>('');
+  const [name, setName] = useState('');
+  const [url, setUrl] = useState('');
+  const [price, setPrice] = useState('');
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!selectedWishlistId || !name.trim()) return;
+    await onSubmit(selectedWishlistId, {
+      name: name.trim(),
+      url: url.trim() || undefined,
+      price: price ? parseFloat(price) : undefined,
+    });
+    setName('');
+    setUrl('');
+    setPrice('');
+  };
+
+  if (wishlists.length === 0) {
+    return (
+      <div className="empty-state">
+        <p>Create a wishlist above to start adding items.</p>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      className="stacked-form"
+      onSubmit={(event) => {
+        void handleSubmit(event);
+      }}
+    >
+      <label htmlFor="add-item-wishlist">Add item</label>
+      <select
+        id="add-item-wishlist"
+        value={selectedWishlistId}
+        onChange={(event) => setSelectedWishlistId(Number(event.target.value))}
+        disabled={loading}
+      >
+        <option value="">Select a wishlist</option>
+        {wishlists.map((w) => (
+          <option key={w.id} value={w.id}>
+            {w.title}
+          </option>
+        ))}
+      </select>
+      <input
+        type="text"
+        placeholder="Item name"
+        value={name}
+        onChange={(event) => setName(event.target.value)}
+        disabled={loading}
+      />
+      <input
+        type="url"
+        placeholder="URL (optional)"
+        value={url}
+        onChange={(event) => setUrl(event.target.value)}
+        disabled={loading}
+      />
+      <input
+        type="number"
+        placeholder="Price (optional)"
+        min="0"
+        step="0.01"
+        value={price}
+        onChange={(event) => setPrice(event.target.value)}
+        disabled={loading}
+      />
+      {error && <p className="form-error">{error}</p>}
+      <button
+        type="submit"
+        className="primary-action"
+        disabled={loading || !selectedWishlistId || !name.trim()}
+      >
+        {loading ? 'Adding...' : 'Add item'}
+      </button>
+    </form>
+  );
+}

--- a/apps/web/src/components/AddItemForm.tsx
+++ b/apps/web/src/components/AddItemForm.tsx
@@ -3,7 +3,7 @@ import type { WishlistSummary } from '../types/wishlist';
 
 interface AddItemFormProps {
   wishlists: WishlistSummary[];
-  onSubmit: (wishlistId: number, data: { name: string; url?: string; price?: number }) => Promise<void>;
+  onSubmit: (wishlistId: number | null, data: { name: string; url?: string; price?: number }) => Promise<void>;
   loading: boolean;
   error: string | null;
 }
@@ -16,8 +16,17 @@ export default function AddItemForm({ wishlists, onSubmit, loading, error }: Add
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!selectedWishlistId || !name.trim()) return;
-    await onSubmit(selectedWishlistId, {
+    if (!name.trim()) return;
+
+    const wishlistId = wishlists.length === 0
+      ? null
+      : selectedWishlistId === ''
+        ? null
+        : selectedWishlistId;
+
+    if (wishlists.length > 0 && wishlistId === null) return;
+
+    await onSubmit(wishlistId, {
       name: name.trim(),
       url: url.trim() || undefined,
       price: price ? parseFloat(price) : undefined,
@@ -27,14 +36,6 @@ export default function AddItemForm({ wishlists, onSubmit, loading, error }: Add
     setPrice('');
   };
 
-  if (wishlists.length === 0) {
-    return (
-      <div className="empty-state">
-        <p>Create a wishlist above to start adding items.</p>
-      </div>
-    );
-  }
-
   return (
     <form
       className="stacked-form"
@@ -42,21 +43,26 @@ export default function AddItemForm({ wishlists, onSubmit, loading, error }: Add
         void handleSubmit(event);
       }}
     >
-      <label htmlFor="add-item-wishlist">Add item</label>
-      <select
-        id="add-item-wishlist"
-        value={selectedWishlistId}
-        onChange={(event) => setSelectedWishlistId(Number(event.target.value))}
-        disabled={loading}
-      >
-        <option value="">Select a wishlist</option>
-        {wishlists.map((w) => (
-          <option key={w.id} value={w.id}>
-            {w.title}
-          </option>
-        ))}
-      </select>
+      <label htmlFor="add-item-name">Add item</label>
+      {wishlists.length === 0 ? (
+        <p className="subtle">Will be added to your default wishlist "My Wishlist".</p>
+      ) : (
+        <select
+          id="add-item-wishlist"
+          value={selectedWishlistId}
+          onChange={(event) => setSelectedWishlistId(Number(event.target.value))}
+          disabled={loading}
+        >
+          <option value="">Select a wishlist</option>
+          {wishlists.map((w) => (
+            <option key={w.id} value={w.id}>
+              {w.title}
+            </option>
+          ))}
+        </select>
+      )}
       <input
+        id="add-item-name"
         type="text"
         placeholder="Item name"
         value={name}
@@ -83,7 +89,7 @@ export default function AddItemForm({ wishlists, onSubmit, loading, error }: Add
       <button
         type="submit"
         className="primary-action"
-        disabled={loading || !selectedWishlistId || !name.trim()}
+        disabled={loading || !name.trim() || (wishlists.length > 0 && !selectedWishlistId)}
       >
         {loading ? 'Adding...' : 'Add item'}
       </button>

--- a/apps/web/src/components/AppHeader.tsx
+++ b/apps/web/src/components/AppHeader.tsx
@@ -1,0 +1,19 @@
+interface AppHeaderProps {
+  userName: string;
+  onSignOut: () => void;
+}
+
+export default function AppHeader({ userName, onSignOut }: AppHeaderProps) {
+  return (
+    <div className="app-header">
+      <div>
+        <p className="eyebrow">Wishlist</p>
+        <h1>Wishlists</h1>
+        <p className="subtle">Signed in as {userName}</p>
+      </div>
+      <button className="secondary-action" onClick={onSignOut}>
+        Sign out
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/BottomTabs.tsx
+++ b/apps/web/src/components/BottomTabs.tsx
@@ -1,0 +1,28 @@
+export type AppTab = 'wishlist' | 'feed' | 'families';
+
+interface BottomTabsProps {
+  activeTab: AppTab;
+  onChange: (tab: AppTab) => void;
+}
+
+const TABS: { id: AppTab; label: string }[] = [
+  { id: 'wishlist', label: 'My Wishlist' },
+  { id: 'feed', label: 'Feed' },
+  { id: 'families', label: 'Families' },
+];
+
+export default function BottomTabs({ activeTab, onChange }: BottomTabsProps) {
+  return (
+    <nav className="bottom-tabs">
+      {TABS.map((tab) => (
+        <button
+          key={tab.id}
+          className={`tab-button${activeTab === tab.id ? ' tab-button--active' : ''}`}
+          onClick={() => onChange(tab.id)}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </nav>
+  );
+}

--- a/apps/web/src/components/CreateWishlistForm.tsx
+++ b/apps/web/src/components/CreateWishlistForm.tsx
@@ -1,0 +1,42 @@
+import { useState, type FormEvent } from 'react';
+
+interface CreateWishlistFormProps {
+  onSubmit: (title: string) => Promise<void>;
+  loading: boolean;
+  error: string | null;
+}
+
+export default function CreateWishlistForm({ onSubmit, loading, error }: CreateWishlistFormProps) {
+  const [title, setTitle] = useState('');
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmed = title.trim();
+    if (!trimmed) return;
+    await onSubmit(trimmed);
+    setTitle('');
+  };
+
+  return (
+    <form
+      className="stacked-form"
+      onSubmit={(event) => {
+        void handleSubmit(event);
+      }}
+    >
+      <label htmlFor="create-wishlist-title">Create wishlist</label>
+      <input
+        id="create-wishlist-title"
+        type="text"
+        placeholder="Wishlist name"
+        value={title}
+        onChange={(event) => setTitle(event.target.value)}
+        disabled={loading}
+      />
+      {error && <p className="form-error">{error}</p>}
+      <button type="submit" className="primary-action" disabled={loading || !title.trim()}>
+        {loading ? 'Creating...' : 'Create wishlist'}
+      </button>
+    </form>
+  );
+}

--- a/apps/web/src/components/FamiliesPanel.tsx
+++ b/apps/web/src/components/FamiliesPanel.tsx
@@ -1,5 +1,6 @@
 import type { FormEvent } from 'react';
 import type { FamilyInviteSummary, FamilySummary } from '../types/wishlist';
+import UserSearchPanel from './UserSearchPanel';
 
 interface FamiliesPanelProps {
   families: FamilySummary[];
@@ -15,6 +16,9 @@ interface FamiliesPanelProps {
   onCreateFamily: (event: FormEvent<HTMLFormElement>) => void;
   onCreateInvite: (familyId: number) => void;
   onRevokeInvite: (familyId: number, inviteId: number) => void;
+  onAddMember?: (familyId: number, userId: number) => Promise<void>;
+  addMemberLoading?: boolean;
+  addMemberError?: string | null;
 }
 
 export default function FamiliesPanel({
@@ -31,6 +35,9 @@ export default function FamiliesPanel({
   onCreateFamily,
   onCreateInvite,
   onRevokeInvite,
+  onAddMember,
+  addMemberLoading = false,
+  addMemberError = null,
 }: FamiliesPanelProps) {
   return (
     <section className="panel">
@@ -60,6 +67,14 @@ export default function FamiliesPanel({
       </div>
       {familyError && <p className="form-error">{familyError}</p>}
       {familyNotice && <p className="form-notice">{familyNotice}</p>}
+      {onAddMember && (
+        <UserSearchPanel
+          families={families}
+          onAddMember={onAddMember}
+          addMemberLoading={addMemberLoading}
+          addMemberError={addMemberError}
+        />
+      )}
       <div className="family-list">
         {families.length === 0 ? (
           <div className="empty-state">

--- a/apps/web/src/components/FamiliesPanel.tsx
+++ b/apps/web/src/components/FamiliesPanel.tsx
@@ -1,0 +1,141 @@
+import type { FormEvent } from 'react';
+import type { FamilyInviteSummary, FamilySummary } from '../types/wishlist';
+
+interface FamiliesPanelProps {
+  families: FamilySummary[];
+  familyInvites: Record<number, FamilyInviteSummary[]>;
+  latestInviteLinks: Record<number, string>;
+  familyLoading: boolean;
+  inviteAcceptanceLoading: boolean;
+  inviteActionFamilyId: number | null;
+  familyError: string | null;
+  familyNotice: string | null;
+  familyForm: { createName: string };
+  onCreateFamilyFormChange: (value: string) => void;
+  onCreateFamily: (event: FormEvent<HTMLFormElement>) => void;
+  onCreateInvite: (familyId: number) => void;
+  onRevokeInvite: (familyId: number, inviteId: number) => void;
+}
+
+export default function FamiliesPanel({
+  families,
+  familyInvites,
+  latestInviteLinks,
+  familyLoading,
+  inviteAcceptanceLoading,
+  inviteActionFamilyId,
+  familyError,
+  familyNotice,
+  familyForm,
+  onCreateFamilyFormChange,
+  onCreateFamily,
+  onCreateInvite,
+  onRevokeInvite,
+}: FamiliesPanelProps) {
+  return (
+    <section className="panel">
+      <div className="panel-header">
+        <div>
+          <h2>Your families</h2>
+          <p className="subtle">
+            Wishlist visibility is limited to people who share at least one family with you.
+          </p>
+        </div>
+        {(familyLoading || inviteAcceptanceLoading) && <span className="pill">Refreshing</span>}
+      </div>
+      <div className="family-forms family-forms-single">
+        <form className="stacked-form" onSubmit={onCreateFamily}>
+          <label htmlFor="create-family-name">Create family</label>
+          <input
+            id="create-family-name"
+            type="text"
+            placeholder="Family name"
+            value={familyForm.createName}
+            onChange={(event) => onCreateFamilyFormChange(event.target.value)}
+          />
+          <button type="submit" className="primary-action">
+            Create family
+          </button>
+        </form>
+      </div>
+      {familyError && <p className="form-error">{familyError}</p>}
+      {familyNotice && <p className="form-notice">{familyNotice}</p>}
+      <div className="family-list">
+        {families.length === 0 ? (
+          <div className="empty-state">
+            <h3>No families yet</h3>
+            <p>Create one to start sharing invite links with relatives.</p>
+          </div>
+        ) : (
+          families.map((family) => (
+            <article className="family-card" key={family.id}>
+              <div className="family-card-header">
+                <div>
+                  <h3>{family.name}</h3>
+                  <div className="family-card-meta">
+                    <span className="pill">{family.memberCount} members</span>
+                    <span className="role-pill">{family.currentUserRole}</span>
+                  </div>
+                </div>
+              </div>
+              <ul className="family-members">
+                {family.members.map((member) => (
+                  <li key={member.id}>
+                    <strong>{member.name}</strong>
+                    <span>{member.email}</span>
+                  </li>
+                ))}
+              </ul>
+              {family.currentUserRole === 'admin' && (
+                <div className="invite-panel">
+                  <div className="invite-panel-header">
+                    <h4>Invite links</h4>
+                    <button
+                      className="secondary-action"
+                      onClick={() => onCreateInvite(family.id)}
+                    >
+                      {inviteActionFamilyId === family.id ? 'Working...' : 'Create invite link'}
+                    </button>
+                  </div>
+                  {latestInviteLinks[family.id] && (
+                    <div className="invite-link-card">
+                      <label htmlFor={`invite-link-${family.id}`}>Latest invite link</label>
+                      <input
+                        id={`invite-link-${family.id}`}
+                        type="text"
+                        readOnly
+                        value={latestInviteLinks[family.id]}
+                      />
+                    </div>
+                  )}
+                  {(familyInvites[family.id] ?? []).length === 0 ? (
+                    <p className="subtle">No active invites.</p>
+                  ) : (
+                    <ul className="invite-list">
+                      {(familyInvites[family.id] ?? []).map((invite) => (
+                        <li key={invite.id}>
+                          <div>
+                            <strong>
+                              Expires {new Date(invite.expiresAt).toLocaleString()}
+                            </strong>
+                            <p className="subtle">Created by {invite.createdByUser.name}</p>
+                          </div>
+                          <button
+                            className="secondary-action"
+                            onClick={() => onRevokeInvite(family.id, invite.id)}
+                          >
+                            Revoke
+                          </button>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              )}
+            </article>
+          ))
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/FollowUserRow.tsx
+++ b/apps/web/src/components/FollowUserRow.tsx
@@ -1,0 +1,21 @@
+import type { FamilyMember } from '../types/wishlist';
+
+interface FollowUserRowProps {
+  member: FamilyMember;
+  familyName: string;
+  onViewWishlist: (userId: number) => void;
+}
+
+export default function FollowUserRow({ member, familyName, onViewWishlist }: FollowUserRowProps) {
+  return (
+    <div className="follow-user-row">
+      <div>
+        <strong>{member.name}</strong>
+        <span className="subtle"> &mdash; {familyName}</span>
+      </div>
+      <button className="secondary-action" onClick={() => onViewWishlist(member.id)}>
+        View wishlist
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/StatsRow.tsx
+++ b/apps/web/src/components/StatsRow.tsx
@@ -1,0 +1,15 @@
+interface StatsRowProps {
+  myItemCount: number;
+  myWishlistCount: number;
+  familyCount: number;
+}
+
+export default function StatsRow({ myItemCount, myWishlistCount, familyCount }: StatsRowProps) {
+  return (
+    <div className="stats-row">
+      <span className="pill">{myItemCount} {myItemCount === 1 ? 'item' : 'items'}</span>
+      <span className="pill">{myWishlistCount} {myWishlistCount === 1 ? 'wishlist' : 'wishlists'}</span>
+      <span className="pill">{familyCount} {familyCount === 1 ? 'family' : 'families'}</span>
+    </div>
+  );
+}

--- a/apps/web/src/components/UserSearchPanel.tsx
+++ b/apps/web/src/components/UserSearchPanel.tsx
@@ -1,0 +1,127 @@
+import { useState, type FormEvent } from 'react';
+import type { FamilySummary, UserSearchResult } from '../types/wishlist';
+import { searchUsers } from '../api/users';
+
+interface UserSearchPanelProps {
+  families: FamilySummary[];
+  onAddMember: (familyId: number, userId: number) => Promise<void>;
+  addMemberLoading: boolean;
+  addMemberError: string | null;
+}
+
+export default function UserSearchPanel({
+  families,
+  onAddMember,
+  addMemberLoading,
+  addMemberError,
+}: UserSearchPanelProps) {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<UserSearchResult[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
+  const [selectedFamilyId, setSelectedFamilyId] = useState<Record<number, number>>({});
+  const [addedUserIds, setAddedUserIds] = useState<Set<number>>(new Set());
+
+  const adminFamilies = families.filter((f) => f.currentUserRole === 'admin');
+
+  if (adminFamilies.length === 0) {
+    return null;
+  }
+
+  const defaultFamilyId = adminFamilies[0]?.id;
+
+  const handleSearch = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!query.trim()) return;
+    setSearching(true);
+    setSearchError(null);
+    try {
+      const data = await searchUsers(query.trim());
+      setResults(data);
+      if (data.length === 0) setSearchError('No users found.');
+    } catch (err) {
+      setSearchError(err instanceof Error ? err.message : 'Search failed');
+    } finally {
+      setSearching(false);
+    }
+  };
+
+  const handleAdd = async (userId: number) => {
+    const familyId = selectedFamilyId[userId] ?? defaultFamilyId;
+    if (!familyId) return;
+    await onAddMember(familyId, userId);
+    setAddedUserIds((prev) => new Set(prev).add(userId));
+  };
+
+  return (
+    <div className="user-search-panel">
+      <h3>Find people</h3>
+      <p className="subtle">Search for other users to add directly to one of your families.</p>
+      <form
+        className="user-search-form"
+        onSubmit={(event) => {
+          void handleSearch(event);
+        }}
+      >
+        <input
+          type="text"
+          placeholder="Search by name or email"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          disabled={searching}
+        />
+        <button type="submit" className="secondary-action" disabled={searching || !query.trim()}>
+          {searching ? 'Searching...' : 'Search'}
+        </button>
+      </form>
+      {searchError && <p className="subtle" style={{ marginTop: '0.5rem' }}>{searchError}</p>}
+      {addMemberError && <p className="form-error">{addMemberError}</p>}
+      {results.length > 0 && (
+        <ul className="user-search-results">
+          {results.map((user) => {
+            const wasAdded = addedUserIds.has(user.id);
+            return (
+              <li key={user.id} className="user-search-result-row">
+                <div>
+                  <strong>{user.name}</strong>
+                  <span className="subtle"> {user.email}</span>
+                </div>
+                {wasAdded ? (
+                  <span className="pill">Added</span>
+                ) : (
+                  <div className="user-search-result-actions">
+                    {adminFamilies.length > 1 && (
+                      <select
+                        value={selectedFamilyId[user.id] ?? defaultFamilyId}
+                        onChange={(event) =>
+                          setSelectedFamilyId((prev) => ({
+                            ...prev,
+                            [user.id]: Number(event.target.value),
+                          }))
+                        }
+                        disabled={addMemberLoading}
+                      >
+                        {adminFamilies.map((f) => (
+                          <option key={f.id} value={f.id}>
+                            {f.name}
+                          </option>
+                        ))}
+                      </select>
+                    )}
+                    <button
+                      className="secondary-action"
+                      onClick={() => void handleAdd(user.id)}
+                      disabled={addMemberLoading}
+                    >
+                      {addMemberLoading ? 'Adding...' : `Add to ${adminFamilies.length === 1 ? adminFamilies[0].name : 'family'}`}
+                    </button>
+                  </div>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/WishlistItemCard.tsx
+++ b/apps/web/src/components/WishlistItemCard.tsx
@@ -23,8 +23,8 @@ export default function WishlistItemCard({
     try {
       await onEdit(id, {
         name: editName.trim() || name,
-        url: editUrl.trim() || undefined,
-        price: editPrice ? parseFloat(editPrice) : undefined,
+        url: editUrl.trim() || null,
+        price: editPrice ? parseFloat(editPrice) : null,
       });
       setIsEditing(false);
     } finally {

--- a/apps/web/src/components/WishlistItemCard.tsx
+++ b/apps/web/src/components/WishlistItemCard.tsx
@@ -1,0 +1,112 @@
+import { useState } from 'react';
+import type { CardProps } from '../types/wishlist';
+
+export default function WishlistItemCard({
+  id,
+  name,
+  ownerName,
+  wishlistTitle,
+  url,
+  price,
+  isOwner,
+  onDelete,
+  onEdit,
+}: CardProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editName, setEditName] = useState(name);
+  const [editUrl, setEditUrl] = useState(url ?? '');
+  const [editPrice, setEditPrice] = useState(price != null ? String(price) : '');
+  const [saving, setSaving] = useState(false);
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      await onEdit(id, {
+        name: editName.trim() || name,
+        url: editUrl.trim() || undefined,
+        price: editPrice ? parseFloat(editPrice) : undefined,
+      });
+      setIsEditing(false);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleCancel = () => {
+    setEditName(name);
+    setEditUrl(url ?? '');
+    setEditPrice(price != null ? String(price) : '');
+    setIsEditing(false);
+  };
+
+  if (isEditing) {
+    return (
+      <div className="card">
+        <div className="card-body">
+          <input
+            type="text"
+            value={editName}
+            onChange={(e) => setEditName(e.target.value)}
+            placeholder="Item name"
+            disabled={saving}
+          />
+          <input
+            type="url"
+            value={editUrl}
+            onChange={(e) => setEditUrl(e.target.value)}
+            placeholder="URL (optional)"
+            disabled={saving}
+          />
+          <input
+            type="number"
+            value={editPrice}
+            onChange={(e) => setEditPrice(e.target.value)}
+            placeholder="Price (optional)"
+            min="0"
+            step="0.01"
+            disabled={saving}
+          />
+        </div>
+        <div className="card-actions">
+          <button
+            className="primary-action"
+            onClick={() => void handleSave()}
+            disabled={saving || !editName.trim()}
+          >
+            {saving ? 'Saving...' : 'Save'}
+          </button>
+          <button className="secondary-action" onClick={handleCancel} disabled={saving}>
+            Cancel
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="card">
+      <div className="card-body">
+        <h3 className="card-title">{name}</h3>
+        <p className="subtle">
+          {ownerName} &mdash; {wishlistTitle}
+        </p>
+        {url && (
+          <a href={url} target="_blank" rel="noopener noreferrer" className="card-link">
+            View item
+          </a>
+        )}
+        {price != null && <p className="card-price">${price.toFixed(2)}</p>}
+      </div>
+      {isOwner && (
+        <div className="card-actions">
+          <button className="secondary-action" onClick={() => setIsEditing(true)}>
+            Edit
+          </button>
+          <button className="secondary-action" onClick={() => onDelete(id)}>
+            Delete
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/index.ts
+++ b/apps/web/src/components/index.ts
@@ -22,3 +22,4 @@ export { default as AddItemForm } from './AddItemForm';
 export { default as WishlistItemCard } from './WishlistItemCard';
 export { default as FamiliesPanel } from './FamiliesPanel';
 export { default as FollowUserRow } from './FollowUserRow';
+export { default as UserSearchPanel } from './UserSearchPanel';

--- a/apps/web/src/components/index.ts
+++ b/apps/web/src/components/index.ts
@@ -12,3 +12,13 @@ export * from './Button';
 
 export { default as DropDown } from './Dropdown';
 export * from './Dropdown';
+
+export { default as AppHeader } from './AppHeader';
+export { default as StatsRow } from './StatsRow';
+export { default as BottomTabs } from './BottomTabs';
+export type { AppTab } from './BottomTabs';
+export { default as CreateWishlistForm } from './CreateWishlistForm';
+export { default as AddItemForm } from './AddItemForm';
+export { default as WishlistItemCard } from './WishlistItemCard';
+export { default as FamiliesPanel } from './FamiliesPanel';
+export { default as FollowUserRow } from './FollowUserRow';

--- a/apps/web/src/types/wishlist.tsx
+++ b/apps/web/src/types/wishlist.tsx
@@ -2,9 +2,11 @@ import type {
   PaginatedWishlistItems,
   PaginationMeta,
   WishlistItemResponse,
+  WishlistSummary,
+  UpdateWishlistItemInput,
 } from '@wishlist/shared';
 
-export type { WishlistItemResponse, PaginationMeta, PaginatedWishlistItems };
+export type { WishlistItemResponse, PaginationMeta, PaginatedWishlistItems, WishlistSummary, UpdateWishlistItemInput };
 
 export interface AuthUser {
   id: number;
@@ -47,5 +49,7 @@ export interface CreatedFamilyInvite extends FamilyInviteSummary {
 }
 
 export interface CardProps extends WishlistItemResponse {
+  isOwner: boolean;
   onDelete: (id: number) => void;
+  onEdit: (id: number, data: UpdateWishlistItemInput) => Promise<void>;
 }

--- a/apps/web/src/types/wishlist.tsx
+++ b/apps/web/src/types/wishlist.tsx
@@ -4,9 +4,10 @@ import type {
   WishlistItemResponse,
   WishlistSummary,
   UpdateWishlistItemInput,
+  UserSearchResult,
 } from '@wishlist/shared';
 
-export type { WishlistItemResponse, PaginationMeta, PaginatedWishlistItems, WishlistSummary, UpdateWishlistItemInput };
+export type { WishlistItemResponse, PaginationMeta, PaginatedWishlistItems, WishlistSummary, UpdateWishlistItemInput, UserSearchResult };
 
 export interface AuthUser {
   id: number;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -52,3 +52,9 @@ export type UpdateWishlistItemInput = {
   url?: string;
   price?: number;
 };
+
+export type UserSearchResult = {
+  id: number;
+  name: string;
+  email: string;
+};

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -49,8 +49,8 @@ export type WishlistSummary = {
 
 export type UpdateWishlistItemInput = {
   name?: string;
-  url?: string;
-  price?: number;
+  url?: string | null;
+  price?: number | null;
 };
 
 export type UserSearchResult = {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -37,3 +37,18 @@ export type AuthUser = {
 export type AuthResponse = {
   user: AuthUser;
 };
+
+export type WishlistSummary = {
+  id: number;
+  title: string;
+  userId: number;
+  itemCount: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type UpdateWishlistItemInput = {
+  name?: string;
+  url?: string;
+  price?: number;
+};


### PR DESCRIPTION
## Summary

- **Backend:** 3 new endpoints (`POST /api/wishlists`, `GET /api/wishlists/mine`, `PATCH /api/wishlist-items/:id`), schema migration adding `updatedAt` to `Wishlist` and `WishlistItem`, new DTOs for create-wishlist and update-wishlist-item
- **Frontend:** Decompose monolithic `App.tsx` into 8 reusable components; tabbed home screen (My Wishlist / Feed / Families) with mobile-first bottom tab bar and desktop top tab row

## Closes

Closes #28
Closes #29
Closes #30
Closes #31
Closes #42
Closes #43
Closes #44
Closes #45

## New Components

| Component | Purpose |
|-----------|---------|
| `AppHeader` | Header with signed-in user + sign out |
| `StatsRow` | Counts row: items · wishlists · families |
| `BottomTabs` | Tab navigation — fixed bottom on mobile, top row on desktop |
| `CreateWishlistForm` | Create a named wishlist |
| `AddItemForm` | Wishlist picker + name/URL/price inputs |
| `WishlistItemCard` | Item card with inline edit mode (owner-only), replaces `Card` |
| `FamiliesPanel` | Extracted family management JSX (no logic change) |
| `FollowUserRow` | Family member row → "View wishlist" filters the feed |

## Test plan

- [ ] `GET /api/wishlists/mine` returns empty array for new user, list after creating wishlists
- [ ] `POST /api/wishlists` creates a wishlist; appears in My Wishlist tab
- [ ] Add item form populates wishlist picker from `GET /api/wishlists/mine`; added item appears in feed and My Wishlist tab
- [ ] `PATCH /api/wishlist-items/:id` — inline edit on `WishlistItemCard` saves changes; 403 if not owner
- [ ] Delete still works from both My Wishlist and Feed tabs
- [ ] Non-owner items in Feed show no Edit/Delete buttons
- [ ] "View wishlist" in FollowUserRow switches to Feed tab filtered by that user
- [ ] Bottom tab bar is fixed at bottom on mobile; becomes top row on `≥768px`
- [ ] All 38 existing API tests pass (`npm test` in `apps/api`)
- [ ] No TypeScript errors (`tsc --noEmit` in both `apps/api` and `apps/web`)
- [ ] Migration applies cleanly on fresh DB (`npx prisma migrate dev`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)