### PR TITLE
Milestone 8: Sharing, viewing, and claiming

### DIFF
--- a/apps/api/prisma/migrations/20260327210914_add_wishlist_item_claim/migration.sql
+++ b/apps/api/prisma/migrations/20260327210914_add_wishlist_item_claim/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE "WishlistItemClaim" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "wishlistItemId" INTEGER NOT NULL,
+    "claimedByUserId" INTEGER NOT NULL,
+    "claimedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "WishlistItemClaim_wishlistItemId_fkey" FOREIGN KEY ("wishlistItemId") REFERENCES "WishlistItem" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "WishlistItemClaim_claimedByUserId_fkey" FOREIGN KEY ("claimedByUserId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "WishlistItemClaim_wishlistItemId_key" ON "WishlistItemClaim"("wishlistItemId");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -21,6 +21,7 @@ model User {
   createdFamilies     Family[]             @relation("FamilyCreator")
   createdFamilyInvites FamilyInvite[]      @relation("FamilyInviteCreator")
   wishlists           Wishlist[]
+  claims              WishlistItemClaim[]
   createdAt           DateTime             @default(now())
   updatedAt           DateTime             @updatedAt
 }
@@ -93,12 +94,23 @@ model Wishlist {
 }
 
 model WishlistItem {
-  id         Int      @id @default(autoincrement())
+  id         Int                @id @default(autoincrement())
   name       String
   url        String?
   price      Float?
-  createdAt  DateTime @default(now())
-  updatedAt  DateTime @updatedAt
-  wishlist   Wishlist @relation(fields: [wishlistId], references: [id])
+  createdAt  DateTime           @default(now())
+  updatedAt  DateTime           @updatedAt
+  wishlist   Wishlist           @relation(fields: [wishlistId], references: [id])
   wishlistId Int
+  claim      WishlistItemClaim?
+}
+
+model WishlistItemClaim {
+  id              Int          @id @default(autoincrement())
+  wishlistItemId  Int          @unique
+  claimedByUserId Int
+  claimedAt       DateTime     @default(now())
+
+  wishlistItem    WishlistItem @relation(fields: [wishlistItemId], references: [id], onDelete: Cascade)
+  claimedByUser   User         @relation(fields: [claimedByUserId], references: [id], onDelete: Cascade)
 }

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -1,13 +1,17 @@
-import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { Controller, Get, Param, ParseIntPipe, Query, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '../auth/auth.guard';
 import { CurrentUser } from '../auth/current-user.decorator';
 import type { AuthenticatedUser } from '../auth/auth.types';
 import { UsersService } from './users.service';
+import { WishlistsService } from '../wishlists/wishlists.service';
 
 @Controller('users')
 @UseGuards(AuthGuard)
 export class UsersController {
-  constructor(private readonly usersService: UsersService) {}
+  constructor(
+    private readonly usersService: UsersService,
+    private readonly wishlistsService: WishlistsService,
+  ) {}
 
   @Get('search')
   searchUsers(
@@ -15,5 +19,13 @@ export class UsersController {
     @Query('q') q: string = '',
   ) {
     return this.usersService.searchUsers(user.id, q);
+  }
+
+  @Get(':userId/wishlists')
+  listUserWishlists(
+    @Param('userId', ParseIntPipe) userId: number,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.wishlistsService.listUserWishlists(user.id, userId);
   }
 }

--- a/apps/api/src/users/users.module.ts
+++ b/apps/api/src/users/users.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
+import { WishlistsModule } from '../wishlists/wishlists.module';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 
 @Module({
+  imports: [WishlistsModule],
   controllers: [UsersController],
   providers: [UsersService],
 })

--- a/apps/api/src/wishlist-items/wishlist-items.controller.ts
+++ b/apps/api/src/wishlist-items/wishlist-items.controller.ts
@@ -8,6 +8,7 @@ import {
   Param,
   ParseIntPipe,
   Patch,
+  Post,
   Query,
   UseGuards,
 } from '@nestjs/common';
@@ -57,6 +58,24 @@ export class WishlistItemsController {
     @CurrentUser() user: AuthenticatedUser,
   ) {
     return this.wishlistItemsService.updateWishlistItem(id, dto, user.id);
+  }
+
+  @Post(':id/claim')
+  @HttpCode(200)
+  claimItem(
+    @Param('id', ParseIntPipe) id: number,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.wishlistItemsService.claimItem(id, user.id);
+  }
+
+  @Post(':id/unclaim')
+  @HttpCode(204)
+  unclaimItem(
+    @Param('id', ParseIntPipe) id: number,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.wishlistItemsService.unclaimItem(id, user.id);
   }
 
   @Delete(':id')

--- a/apps/api/src/wishlist-items/wishlist-items.service.spec.ts
+++ b/apps/api/src/wishlist-items/wishlist-items.service.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/unbound-method */
-import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { ConflictException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { Test, TestingModule } from '@nestjs/testing';
 import { FamiliesService } from '../families/families.service';
@@ -12,6 +12,11 @@ describe('WishlistItemsService', () => {
     wishlistItem: {
       findMany: jest.fn(),
       count: jest.fn(),
+      findUnique: jest.fn(),
+      delete: jest.fn(),
+    },
+    wishlistItemClaim: {
+      create: jest.fn(),
       findUnique: jest.fn(),
       delete: jest.fn(),
     },
@@ -287,5 +292,193 @@ describe('WishlistItemsService', () => {
     await expect(service.deleteWishlistItem(999, 7)).rejects.toBeInstanceOf(
       NotFoundException,
     );
+  });
+
+  describe('claimItem', () => {
+    const claimedAt = new Date('2025-06-01');
+
+    it('creates a claim and returns id, wishlistItemId, claimedAt without claimedByUserId', async () => {
+      prismaMock.wishlistItem.findUnique = jest.fn().mockResolvedValue({
+        id: 10,
+        wishlist: { userId: 5 },
+        claim: null,
+      });
+      (familiesServiceMock.assertSharedFamily as jest.Mock).mockResolvedValue(undefined);
+      (prismaMock.wishlistItemClaim.create as jest.Mock).mockResolvedValue({
+        id: 1,
+        wishlistItemId: 10,
+        claimedAt,
+      });
+
+      const result = await service.claimItem(10, 7);
+
+      expect(result).toEqual({ id: 1, wishlistItemId: 10, claimedAt });
+      expect(result).not.toHaveProperty('claimedByUserId');
+      expect(prismaMock.wishlistItemClaim.create).toHaveBeenCalledWith({
+        data: { wishlistItemId: 10, claimedByUserId: 7 },
+        select: { id: true, wishlistItemId: true, claimedAt: true },
+      });
+    });
+
+    it('returns existing claim idempotently when already claimed by current user', async () => {
+      prismaMock.wishlistItem.findUnique = jest.fn().mockResolvedValue({
+        id: 10,
+        wishlist: { userId: 5 },
+        claim: { id: 1, claimedByUserId: 7, claimedAt },
+      });
+      (familiesServiceMock.assertSharedFamily as jest.Mock).mockResolvedValue(undefined);
+
+      const result = await service.claimItem(10, 7);
+
+      expect(result).toEqual({ id: 1, wishlistItemId: 10, claimedAt });
+      expect(prismaMock.wishlistItemClaim.create).not.toHaveBeenCalled();
+    });
+
+    it('throws ConflictException when item is already claimed by a different user', async () => {
+      prismaMock.wishlistItem.findUnique = jest.fn().mockResolvedValue({
+        id: 10,
+        wishlist: { userId: 5 },
+        claim: { id: 1, claimedByUserId: 99, claimedAt },
+      });
+      (familiesServiceMock.assertSharedFamily as jest.Mock).mockResolvedValue(undefined);
+
+      await expect(service.claimItem(10, 7)).rejects.toBeInstanceOf(ConflictException);
+    });
+
+    it('throws ForbiddenException when item belongs to current user', async () => {
+      prismaMock.wishlistItem.findUnique = jest.fn().mockResolvedValue({
+        id: 10,
+        wishlist: { userId: 7 },
+        claim: null,
+      });
+
+      await expect(service.claimItem(10, 7)).rejects.toBeInstanceOf(ForbiddenException);
+      expect(familiesServiceMock.assertSharedFamily).not.toHaveBeenCalled();
+    });
+
+    it('propagates ForbiddenException from assertSharedFamily', async () => {
+      prismaMock.wishlistItem.findUnique = jest.fn().mockResolvedValue({
+        id: 10,
+        wishlist: { userId: 5 },
+        claim: null,
+      });
+      (familiesServiceMock.assertSharedFamily as jest.Mock).mockRejectedValue(
+        new ForbiddenException('No shared family'),
+      );
+
+      await expect(service.claimItem(10, 7)).rejects.toBeInstanceOf(ForbiddenException);
+      expect(prismaMock.wishlistItemClaim.create).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when item does not exist', async () => {
+      prismaMock.wishlistItem.findUnique = jest.fn().mockResolvedValue(null);
+
+      await expect(service.claimItem(999, 7)).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('handles concurrent claim race (P2002): returns existing claim if same user won the race', async () => {
+      prismaMock.wishlistItem.findUnique = jest.fn().mockResolvedValue({
+        id: 10,
+        wishlist: { userId: 5 },
+        claim: null,
+      });
+      (familiesServiceMock.assertSharedFamily as jest.Mock).mockResolvedValue(undefined);
+      const p2002 = new Prisma.PrismaClientKnownRequestError('Unique constraint', {
+        code: 'P2002',
+        clientVersion: 'test',
+        meta: {},
+      });
+      (prismaMock.wishlistItemClaim.create as jest.Mock).mockRejectedValue(p2002);
+      (prismaMock.wishlistItemClaim.findUnique as jest.Mock).mockResolvedValue({
+        id: 1,
+        wishlistItemId: 10,
+        claimedByUserId: 7,
+        claimedAt,
+      });
+
+      const result = await service.claimItem(10, 7);
+
+      expect(result).toEqual({ id: 1, wishlistItemId: 10, claimedAt });
+    });
+
+    it('handles concurrent claim race (P2002): throws ConflictException if different user won the race', async () => {
+      prismaMock.wishlistItem.findUnique = jest.fn().mockResolvedValue({
+        id: 10,
+        wishlist: { userId: 5 },
+        claim: null,
+      });
+      (familiesServiceMock.assertSharedFamily as jest.Mock).mockResolvedValue(undefined);
+      const p2002 = new Prisma.PrismaClientKnownRequestError('Unique constraint', {
+        code: 'P2002',
+        clientVersion: 'test',
+        meta: {},
+      });
+      (prismaMock.wishlistItemClaim.create as jest.Mock).mockRejectedValue(p2002);
+      (prismaMock.wishlistItemClaim.findUnique as jest.Mock).mockResolvedValue({
+        id: 1,
+        wishlistItemId: 10,
+        claimedByUserId: 99,
+        claimedAt,
+      });
+
+      await expect(service.claimItem(10, 7)).rejects.toBeInstanceOf(ConflictException);
+    });
+  });
+
+  describe('unclaimItem', () => {
+    it('deletes the claim and returns void', async () => {
+      prismaMock.wishlistItem.findUnique = jest.fn().mockResolvedValue({
+        id: 10,
+        claim: { id: 1, claimedByUserId: 7 },
+      });
+      (prismaMock.wishlistItemClaim.delete as jest.Mock).mockResolvedValue(undefined);
+
+      await expect(service.unclaimItem(10, 7)).resolves.toBeUndefined();
+
+      expect(prismaMock.wishlistItemClaim.delete).toHaveBeenCalledWith({ where: { id: 1 } });
+    });
+
+    it('returns void without calling delete when no claim exists', async () => {
+      prismaMock.wishlistItem.findUnique = jest.fn().mockResolvedValue({
+        id: 10,
+        claim: null,
+      });
+
+      await expect(service.unclaimItem(10, 7)).resolves.toBeUndefined();
+
+      expect(prismaMock.wishlistItemClaim.delete).not.toHaveBeenCalled();
+    });
+
+    it('throws ForbiddenException when claim belongs to a different user', async () => {
+      prismaMock.wishlistItem.findUnique = jest.fn().mockResolvedValue({
+        id: 10,
+        claim: { id: 1, claimedByUserId: 99 },
+      });
+
+      await expect(service.unclaimItem(10, 7)).rejects.toBeInstanceOf(ForbiddenException);
+
+      expect(prismaMock.wishlistItemClaim.delete).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when item does not exist', async () => {
+      prismaMock.wishlistItem.findUnique = jest.fn().mockResolvedValue(null);
+
+      await expect(service.unclaimItem(999, 7)).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('handles concurrent unclaim race (P2025): returns void idempotently', async () => {
+      prismaMock.wishlistItem.findUnique = jest.fn().mockResolvedValue({
+        id: 10,
+        claim: { id: 1, claimedByUserId: 7 },
+      });
+      const p2025 = new Prisma.PrismaClientKnownRequestError('Not found', {
+        code: 'P2025',
+        clientVersion: 'test',
+        meta: {},
+      });
+      (prismaMock.wishlistItemClaim.delete as jest.Mock).mockRejectedValue(p2025);
+
+      await expect(service.unclaimItem(10, 7)).resolves.toBeUndefined();
+    });
   });
 });

--- a/apps/api/src/wishlist-items/wishlist-items.service.spec.ts
+++ b/apps/api/src/wishlist-items/wishlist-items.service.spec.ts
@@ -46,6 +46,7 @@ describe('WishlistItemsService', () => {
         price: 299,
         createdAt: new Date('2025-01-01'),
         wishlistId: 3,
+        claim: null,
         wishlist: {
           id: 3,
           title: 'Travel',
@@ -133,6 +134,8 @@ describe('WishlistItemsService', () => {
           wishlistTitle: 'Travel',
           ownerId: 7,
           ownerName: 'Alice',
+          isClaimed: false,
+          isClaimedByMe: false,
         },
       ],
       meta: {

--- a/apps/api/src/wishlist-items/wishlist-items.service.ts
+++ b/apps/api/src/wishlist-items/wishlist-items.service.ts
@@ -174,6 +174,8 @@ export class WishlistItemsService {
       throw new ForbiddenException('You cannot claim your own wishlist item');
     }
 
+    await this.familiesService.assertSharedFamily(currentUserId, item.wishlist.userId);
+
     if (item.claim) {
       if (item.claim.claimedByUserId === currentUserId) {
         return { id: item.claim.id, wishlistItemId: itemId, claimedAt: item.claim.claimedAt };
@@ -181,11 +183,27 @@ export class WishlistItemsService {
       throw new ConflictException('This item has already been claimed');
     }
 
-    const claim = await this.prisma.wishlistItemClaim.create({
-      data: { wishlistItemId: itemId, claimedByUserId: currentUserId },
-      select: { id: true, wishlistItemId: true, claimedAt: true },
-    });
-    return claim;
+    try {
+      const claim = await this.prisma.wishlistItemClaim.create({
+        data: { wishlistItemId: itemId, claimedByUserId: currentUserId },
+        select: { id: true, wishlistItemId: true, claimedAt: true },
+      });
+      return claim;
+    } catch (err) {
+      if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2002') {
+        // Race: another request won the insert — re-fetch to determine correct response
+        const existing = await this.prisma.wishlistItemClaim.findUnique({
+          where: { wishlistItemId: itemId },
+          select: { id: true, wishlistItemId: true, claimedByUserId: true, claimedAt: true },
+        });
+        if (!existing) throw err;
+        if (existing.claimedByUserId === currentUserId) {
+          return { id: existing.id, wishlistItemId: itemId, claimedAt: existing.claimedAt };
+        }
+        throw new ConflictException('This item has already been claimed');
+      }
+      throw err;
+    }
   }
 
   async unclaimItem(itemId: number, currentUserId: number) {
@@ -204,7 +222,14 @@ export class WishlistItemsService {
       throw new ForbiddenException('You can only unclaim items you have claimed');
     }
 
-    await this.prisma.wishlistItemClaim.delete({ where: { id: item.claim.id } });
+    try {
+      await this.prisma.wishlistItemClaim.delete({ where: { id: item.claim.id } });
+    } catch (err) {
+      if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2025') {
+        return; // already deleted by a concurrent request — idempotent
+      }
+      throw err;
+    }
   }
 
   async deleteWishlistItem(id: number, currentUserId: number) {

--- a/apps/api/src/wishlist-items/wishlist-items.service.ts
+++ b/apps/api/src/wishlist-items/wishlist-items.service.ts
@@ -1,4 +1,5 @@
 import {
+  ConflictException,
   ForbiddenException,
   Injectable,
   NotFoundException,
@@ -74,6 +75,7 @@ export class WishlistItemsService {
           price: true,
           createdAt: true,
           wishlistId: true,
+          claim: { select: { claimedByUserId: true } },
           wishlist: {
             select: {
               id: true,
@@ -101,6 +103,8 @@ export class WishlistItemsService {
       wishlistTitle: item.wishlist.title,
       ownerId: item.wishlist.user.id,
       ownerName: item.wishlist.user.name,
+      isClaimed: item.claim !== null,
+      isClaimedByMe: item.claim?.claimedByUserId === currentUserId,
     }));
     const totalPages = Math.ceil(total / limit);
     // adding meta data to easily parse the page, limit, total and total pages for later use
@@ -152,6 +156,55 @@ export class WishlistItemsService {
         wishlistId: true,
       },
     });
+  }
+
+  async claimItem(itemId: number, currentUserId: number) {
+    const item = await this.prisma.wishlistItem.findUnique({
+      where: { id: itemId },
+      select: {
+        id: true,
+        wishlist: { select: { userId: true } },
+        claim: { select: { id: true, claimedByUserId: true, claimedAt: true } },
+      },
+    });
+
+    if (!item) throw new NotFoundException(`WishlistItem ${itemId} not found`);
+
+    if (item.wishlist.userId === currentUserId) {
+      throw new ForbiddenException('You cannot claim your own wishlist item');
+    }
+
+    if (item.claim) {
+      if (item.claim.claimedByUserId === currentUserId) {
+        return { id: item.claim.id, wishlistItemId: itemId, claimedAt: item.claim.claimedAt };
+      }
+      throw new ConflictException('This item has already been claimed');
+    }
+
+    const claim = await this.prisma.wishlistItemClaim.create({
+      data: { wishlistItemId: itemId, claimedByUserId: currentUserId },
+      select: { id: true, wishlistItemId: true, claimedAt: true },
+    });
+    return claim;
+  }
+
+  async unclaimItem(itemId: number, currentUserId: number) {
+    const item = await this.prisma.wishlistItem.findUnique({
+      where: { id: itemId },
+      select: {
+        id: true,
+        claim: { select: { id: true, claimedByUserId: true } },
+      },
+    });
+
+    if (!item) throw new NotFoundException(`WishlistItem ${itemId} not found`);
+    if (!item.claim) return;
+
+    if (item.claim.claimedByUserId !== currentUserId) {
+      throw new ForbiddenException('You can only unclaim items you have claimed');
+    }
+
+    await this.prisma.wishlistItemClaim.delete({ where: { id: item.claim.id } });
   }
 
   async deleteWishlistItem(id: number, currentUserId: number) {

--- a/apps/api/src/wishlists/wishlists.controller.ts
+++ b/apps/api/src/wishlists/wishlists.controller.ts
@@ -32,6 +32,14 @@ export class WishlistsController {
     return this.wishlistsService.listMyWishlists(user.id);
   }
 
+  @Get(':wishlistId/items')
+  getWishlistItems(
+    @Param('wishlistId', ParseIntPipe) wishlistId: number,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.wishlistsService.getWishlistItemsForWishlist(user.id, wishlistId);
+  }
+
   @Post(':wishlistId/items')
   createWishlistItem(
     @Param('wishlistId', ParseIntPipe) wishlistId: number,

--- a/apps/api/src/wishlists/wishlists.module.ts
+++ b/apps/api/src/wishlists/wishlists.module.ts
@@ -1,9 +1,12 @@
 import { Module } from '@nestjs/common';
+import { FamiliesModule } from '../families/families.module';
 import { WishlistsController } from './wishlists.controller';
 import { WishlistsService } from './wishlists.service';
 
 @Module({
+  imports: [FamiliesModule],
   controllers: [WishlistsController],
   providers: [WishlistsService],
+  exports: [WishlistsService],
 })
 export class WishlistsModule {}

--- a/apps/api/src/wishlists/wishlists.service.spec.ts
+++ b/apps/api/src/wishlists/wishlists.service.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/unbound-method, @typescript-eslint/no-unsafe-assignment */
-import { NotFoundException } from '@nestjs/common';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { FamiliesService } from '../families/families.service';
 import { PrismaService } from '../prisma/prisma.service';
@@ -10,9 +10,11 @@ describe('WishlistsService', () => {
   const prismaMock = {
     wishlist: {
       findUnique: jest.fn(),
+      findMany: jest.fn(),
     },
     wishlistItem: {
       create: jest.fn(),
+      findMany: jest.fn(),
     },
   } as unknown as PrismaService;
   const familiesServiceMock = {
@@ -82,5 +84,53 @@ describe('WishlistsService', () => {
     ).rejects.toBeInstanceOf(NotFoundException);
 
     expect(prismaMock.wishlistItem.create).not.toHaveBeenCalled();
+  });
+
+  describe('getWishlistItemsForWishlist', () => {
+    const createdAt = new Date('2025-05-01');
+    const wishlist = {
+      id: 3,
+      title: 'Birthday',
+      userId: 5,
+      user: { name: 'Alice' },
+    };
+
+    it('returns items mapped with isClaimed and isClaimedByMe, without claimedByUserId', async () => {
+      prismaMock.wishlist.findUnique = jest.fn().mockResolvedValue(wishlist);
+      (familiesServiceMock.assertSharedFamily as jest.Mock).mockResolvedValue(undefined);
+      prismaMock.wishlistItem.findMany = jest.fn().mockResolvedValue([
+        { id: 1, name: 'Shoes', url: null, price: 50, createdAt, wishlistId: 3, claim: null },
+        { id: 2, name: 'Bag', url: null, price: 80, createdAt, wishlistId: 3, claim: { claimedByUserId: 7 } },
+        { id: 3, name: 'Hat', url: null, price: 30, createdAt, wishlistId: 3, claim: { claimedByUserId: 99 } },
+      ]);
+
+      const result = await service.getWishlistItemsForWishlist(7, 3);
+
+      expect(result).toEqual([
+        { id: 1, name: 'Shoes', url: null, price: 50, createdAt, wishlistId: 3, wishlistTitle: 'Birthday', ownerId: 5, ownerName: 'Alice', isClaimed: false, isClaimedByMe: false },
+        { id: 2, name: 'Bag', url: null, price: 80, createdAt, wishlistId: 3, wishlistTitle: 'Birthday', ownerId: 5, ownerName: 'Alice', isClaimed: true, isClaimedByMe: true },
+        { id: 3, name: 'Hat', url: null, price: 30, createdAt, wishlistId: 3, wishlistTitle: 'Birthday', ownerId: 5, ownerName: 'Alice', isClaimed: true, isClaimedByMe: false },
+      ]);
+      result.forEach((item) => expect(item).not.toHaveProperty('claimedByUserId'));
+    });
+
+    it('throws NotFoundException when wishlist does not exist', async () => {
+      prismaMock.wishlist.findUnique = jest.fn().mockResolvedValue(null);
+
+      await expect(service.getWishlistItemsForWishlist(7, 999)).rejects.toBeInstanceOf(NotFoundException);
+
+      expect(prismaMock.wishlistItem.findMany).not.toHaveBeenCalled();
+    });
+
+    it('propagates ForbiddenException from assertSharedFamily', async () => {
+      prismaMock.wishlist.findUnique = jest.fn().mockResolvedValue(wishlist);
+      (familiesServiceMock.assertSharedFamily as jest.Mock).mockRejectedValue(
+        new ForbiddenException('No shared family'),
+      );
+
+      await expect(service.getWishlistItemsForWishlist(7, 3)).rejects.toBeInstanceOf(ForbiddenException);
+
+      expect(prismaMock.wishlistItem.findMany).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/api/src/wishlists/wishlists.service.spec.ts
+++ b/apps/api/src/wishlists/wishlists.service.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/unbound-method, @typescript-eslint/no-unsafe-assignment */
 import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import { FamiliesService } from '../families/families.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { WishlistsService } from './wishlists.service';
 
@@ -14,12 +15,16 @@ describe('WishlistsService', () => {
       create: jest.fn(),
     },
   } as unknown as PrismaService;
+  const familiesServiceMock = {
+    assertSharedFamily: jest.fn(),
+  } as unknown as FamiliesService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         WishlistsService,
         { provide: PrismaService, useValue: prismaMock },
+        { provide: FamiliesService, useValue: familiesServiceMock },
       ],
     }).compile();
 

--- a/apps/api/src/wishlists/wishlists.service.ts
+++ b/apps/api/src/wishlists/wishlists.service.ts
@@ -4,12 +4,16 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
+import { FamiliesService } from '../families/families.service';
 import { CreateWishlistItemDto } from '../wishlist-items/dto/create-wishlist-item.dto';
 import { CreateWishlistDto } from './dto/create-wishlist.dto';
 
 @Injectable()
 export class WishlistsService {
-  constructor(private prisma: PrismaService) {}
+  constructor(
+    private prisma: PrismaService,
+    private readonly familiesService: FamiliesService,
+  ) {}
 
   async createWishlist(dto: CreateWishlistDto, currentUserId: number) {
     const wishlist = await this.prisma.wishlist.create({
@@ -44,6 +48,62 @@ export class WishlistsService {
     });
     return wishlists.map((w) => ({ ...w, itemCount: w._count.items }));
   }
+  async listUserWishlists(currentUserId: number, targetUserId: number) {
+    await this.familiesService.assertSharedFamily(currentUserId, targetUserId);
+    const wishlists = await this.prisma.wishlist.findMany({
+      where: { userId: targetUserId },
+      orderBy: { createdAt: 'desc' },
+      select: {
+        id: true,
+        title: true,
+        userId: true,
+        createdAt: true,
+        updatedAt: true,
+        _count: { select: { items: true } },
+      },
+    });
+    return wishlists.map((w) => ({ ...w, itemCount: w._count.items }));
+  }
+
+  async getWishlistItemsForWishlist(currentUserId: number, wishlistId: number) {
+    const wishlist = await this.prisma.wishlist.findUnique({
+      where: { id: wishlistId },
+      select: { id: true, title: true, userId: true, user: { select: { name: true } } },
+    });
+
+    if (!wishlist) throw new NotFoundException(`Wishlist ${wishlistId} not found`);
+
+    await this.familiesService.assertSharedFamily(currentUserId, wishlist.userId);
+
+    const items = await this.prisma.wishlistItem.findMany({
+      where: { wishlistId },
+      orderBy: { createdAt: 'desc' },
+      select: {
+        id: true,
+        name: true,
+        url: true,
+        price: true,
+        createdAt: true,
+        wishlistId: true,
+        claim: { select: { claimedByUserId: true } },
+      },
+    });
+
+    return items.map((item) => ({
+      id: item.id,
+      name: item.name,
+      url: item.url,
+      price: item.price,
+      createdAt: item.createdAt,
+      wishlistId: item.wishlistId,
+      wishlistTitle: wishlist.title,
+      ownerId: wishlist.userId,
+      ownerName: wishlist.user.name,
+      isClaimed: item.claim !== null,
+      isClaimedByMe: item.claim?.claimedByUserId === currentUserId,
+    }));
+  }
+
   async createWishlistItem(
     wishlistId: number,
     dto: CreateWishlistItemDto,

--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -332,6 +332,19 @@
   background: #eff6ff;
 }
 
+.wishlist-row-btn {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  text-align: left;
+  cursor: pointer;
+  background: none;
+  border: 1px solid #dbeafe;
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+}
+
 /* ---- Card (WishlistItemCard) ---- */
 .card {
   border-radius: 18px;

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -10,7 +10,7 @@ import {
   getFamilyInvites,
   revokeFamilyInvite,
 } from './api/families';
-import { deleteWishListItem, getWishlistItems, updateWishlistItem } from './api/wishlistItems';
+import { claimWishlistItem, deleteWishListItem, getWishlistItems, unclaimWishlistItem, updateWishlistItem } from './api/wishlistItems';
 import { createWishlist, createWishlistItem, getMyWishlists } from './api/wishlists';
 import { addFamilyMember } from './api/users';
 import AddItemForm from './components/AddItemForm';
@@ -20,6 +20,7 @@ import type { AppTab } from './components/BottomTabs';
 import CreateWishlistForm from './components/CreateWishlistForm';
 import FamiliesPanel from './components/FamiliesPanel';
 import FollowUserRow from './components/FollowUserRow';
+import WishlistDrilldown from './components/WishlistDrilldown';
 import StatsRow from './components/StatsRow';
 import WishlistItemCard from './components/WishlistItemCard';
 import { DropDown, PaginationButtons, UserSearch } from './components/index';
@@ -98,6 +99,9 @@ function App() {
 
   // Tab navigation
   const [activeTab, setActiveTab] = useState<AppTab>('feed');
+
+  // Drill-down navigation (viewing a family member's wishlists)
+  const [viewingUser, setViewingUser] = useState<{ id: number; name: string } | null>(null);
 
   const clearInviteTokenFromUrl = useCallback(() => {
     if (typeof window === 'undefined') return;
@@ -358,6 +362,7 @@ function App() {
       setFamilyNotice(null);
       setAddMemberLoading(false);
       setAddMemberError(null);
+      setViewingUser(null);
     }
   };
 
@@ -472,12 +477,21 @@ function App() {
     }
   };
 
+  const handleClaim = useCallback(async (itemId: number) => {
+    await claimWishlistItem(itemId);
+    await fetchData();
+  }, [fetchData]);
+
+  const handleUnclaim = useCallback(async (itemId: number) => {
+    await unclaimWishlistItem(itemId);
+    await fetchData();
+  }, [fetchData]);
+
+  const handleCloseDrilldown = useCallback(() => setViewingUser(null), []);
+
   const handleViewUserWishlist = (userId: number) => {
     const member = families.flatMap((f) => f.members).find((m) => m.id === userId);
-    if (member) {
-      setInputUserName(member.name);
-      setSearchUserName(member.name);
-    }
+    if (member) setViewingUser({ id: member.id, name: member.name });
     setActiveTab('feed');
   };
 
@@ -699,64 +713,78 @@ function App() {
 
         {activeTab === 'feed' && (
           <section className="panel">
-            <div className="panel-header">
-              <div>
-                <h2>Shared wishlist feed</h2>
-                <p className="subtle">
-                  The feed shows your own items plus wishlists from users who share a family with you.
-                </p>
-              </div>
-            </div>
-            <UserSearch
-              onSubmit={handleSearchSubmit}
-              value={inputUserName}
-              onChange={setInputUserName}
-            />
-            {loading && <h2>Loading...</h2>}
-            {error ? (
-              <div className="empty-state">
-                <h3>{error}</h3>
-              </div>
-            ) : filteredItems.length === 0 ? (
-              <div className="empty-state">
-                <h3>No visible wishlist items</h3>
-                <p>
-                  {families.length === 0
-                    ? 'You can only see your own items until you create or join a family.'
-                    : 'No items match your current family access and search filters.'}
-                </p>
-              </div>
+            {viewingUser ? (
+              <WishlistDrilldown
+                viewingUser={viewingUser}
+                currentUserId={currentUser.id}
+                onBack={handleCloseDrilldown}
+                onClaim={handleClaim}
+                onUnclaim={handleUnclaim}
+              />
             ) : (
               <>
-                <div className="wishlist-stack">
-                  {filteredItems.map((item) => (
-                    <WishlistItemCard
-                      key={item.id}
-                      {...item}
-                      isOwner={item.ownerId === currentUser.id}
-                      onDelete={(id) => {
-                        if (item.ownerId !== currentUser.id) {
-                          setError('You can only delete items from your own wishlist.');
-                          return;
-                        }
-                        void onDeleteItem(id);
-                      }}
-                      onEdit={handleEditItem}
-                    />
-                  ))}
+                <div className="panel-header">
+                  <div>
+                    <h2>Shared wishlist feed</h2>
+                    <p className="subtle">
+                      The feed shows your own items plus wishlists from users who share a family with you.
+                    </p>
+                  </div>
                 </div>
-                <PaginationButtons
-                  handleBackPage={handleBackPage}
-                  handleNextPage={handleNextPage}
-                  currentPage={currentPage}
-                  totalPages={meta?.totalPages}
+                <UserSearch
+                  onSubmit={handleSearchSubmit}
+                  value={inputUserName}
+                  onChange={setInputUserName}
                 />
-                <DropDown
-                  limit={limit}
-                  setLimit={setLimit}
-                  setCurrentPage={setCurrentPage}
-                  totalItems={meta?.total}
-                />
+                {loading && <h2>Loading...</h2>}
+                {error ? (
+                  <div className="empty-state">
+                    <h3>{error}</h3>
+                  </div>
+                ) : filteredItems.length === 0 ? (
+                  <div className="empty-state">
+                    <h3>No visible wishlist items</h3>
+                    <p>
+                      {families.length === 0
+                        ? 'You can only see your own items until you create or join a family.'
+                        : 'No items match your current family access and search filters.'}
+                    </p>
+                  </div>
+                ) : (
+                  <>
+                    <div className="wishlist-stack">
+                      {filteredItems.map((item) => (
+                        <WishlistItemCard
+                          key={item.id}
+                          {...item}
+                          isOwner={item.ownerId === currentUser.id}
+                          onDelete={(id) => {
+                            if (item.ownerId !== currentUser.id) {
+                              setError('You can only delete items from your own wishlist.');
+                              return;
+                            }
+                            void onDeleteItem(id);
+                          }}
+                          onEdit={handleEditItem}
+                          onClaim={item.ownerId !== currentUser.id ? handleClaim : undefined}
+                          onUnclaim={item.ownerId !== currentUser.id ? handleUnclaim : undefined}
+                        />
+                      ))}
+                    </div>
+                    <PaginationButtons
+                      handleBackPage={handleBackPage}
+                      handleNextPage={handleNextPage}
+                      currentPage={currentPage}
+                      totalPages={meta?.totalPages}
+                    />
+                    <DropDown
+                      limit={limit}
+                      setLimit={setLimit}
+                      setCurrentPage={setCurrentPage}
+                      totalItems={meta?.total}
+                    />
+                  </>
+                )}
               </>
             )}
           </section>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -478,13 +478,21 @@ function App() {
   };
 
   const handleClaim = useCallback(async (itemId: number) => {
-    await claimWishlistItem(itemId);
-    await fetchData();
+    try {
+      await claimWishlistItem(itemId);
+      await fetchData();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to claim item');
+    }
   }, [fetchData]);
 
   const handleUnclaim = useCallback(async (itemId: number) => {
-    await unclaimWishlistItem(itemId);
-    await fetchData();
+    try {
+      await unclaimWishlistItem(itemId);
+      await fetchData();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to unclaim item');
+    }
   }, [fetchData]);
 
   const handleCloseDrilldown = useCallback(() => setViewingUser(null), []);
@@ -716,7 +724,6 @@ function App() {
             {viewingUser ? (
               <WishlistDrilldown
                 viewingUser={viewingUser}
-                currentUserId={currentUser.id}
                 onBack={handleCloseDrilldown}
                 onClaim={handleClaim}
                 onUnclaim={handleUnclaim}

--- a/apps/web/src/api/wishlistItems.tsx
+++ b/apps/web/src/api/wishlistItems.tsx
@@ -52,3 +52,14 @@ export function updateWishlistItem(id: number, data: UpdateWishlistItemInput) {
     body: JSON.stringify(data),
   });
 }
+
+export function claimWishlistItem(id: number) {
+  return apiRequest<{ id: number; wishlistItemId: number; claimedAt: string }>(
+    `/api/wishlist-items/${id}/claim`,
+    { method: 'POST' },
+  );
+}
+
+export function unclaimWishlistItem(id: number) {
+  return apiRequest<void>(`/api/wishlist-items/${id}/unclaim`, { method: 'POST' });
+}

--- a/apps/web/src/api/wishlists.ts
+++ b/apps/web/src/api/wishlists.ts
@@ -21,3 +21,11 @@ export function createWishlistItem(
     body: JSON.stringify(data),
   });
 }
+
+export function getUserWishlists(userId: number) {
+  return apiRequest<WishlistSummary[]>(`/api/users/${userId}/wishlists`);
+}
+
+export function getWishlistItemsForWishlist(wishlistId: number) {
+  return apiRequest<WishlistItemResponse[]>(`/api/wishlists/${wishlistId}/items`);
+}

--- a/apps/web/src/components/WishlistDrilldown.tsx
+++ b/apps/web/src/components/WishlistDrilldown.tsx
@@ -5,7 +5,6 @@ import WishlistItemCard from './WishlistItemCard';
 
 interface WishlistDrilldownProps {
   viewingUser: { id: number; name: string };
-  currentUserId: number;
   onBack: () => void;
   onClaim: (itemId: number) => Promise<void>;
   onUnclaim: (itemId: number) => Promise<void>;
@@ -35,6 +34,7 @@ export default function WishlistDrilldown({
   }, [viewingUser.id]);
 
   const fetchItems = useCallback(async (wishlistId: number) => {
+    setItems([]);
     setLoading(true);
     setError(null);
     try {
@@ -54,7 +54,6 @@ export default function WishlistDrilldown({
 
   const handleBackToWishlists = () => {
     setSelectedWishlist(null);
-    setItems([]);
   };
 
   const handleClaim = async (itemId: number) => {
@@ -135,9 +134,8 @@ export default function WishlistDrilldown({
           {wishlists.map((wl) => (
             <button
               key={wl.id}
-              className="wishlist-row"
+              className="wishlist-row-btn"
               onClick={() => void handleSelectWishlist(wl)}
-              style={{ width: '100%', textAlign: 'left', cursor: 'pointer', background: 'none', border: '1px solid #dbeafe' }}
             >
               <strong>{wl.title}</strong>
               <span className="pill">

--- a/apps/web/src/components/WishlistDrilldown.tsx
+++ b/apps/web/src/components/WishlistDrilldown.tsx
@@ -1,0 +1,152 @@
+import { useCallback, useEffect, useState } from 'react';
+import { getUserWishlists, getWishlistItemsForWishlist } from '../api/wishlists';
+import type { WishlistItemResponse, WishlistSummary } from '../types/wishlist';
+import WishlistItemCard from './WishlistItemCard';
+
+interface WishlistDrilldownProps {
+  viewingUser: { id: number; name: string };
+  currentUserId: number;
+  onBack: () => void;
+  onClaim: (itemId: number) => Promise<void>;
+  onUnclaim: (itemId: number) => Promise<void>;
+}
+
+export default function WishlistDrilldown({
+  viewingUser,
+  onBack,
+  onClaim,
+  onUnclaim,
+}: WishlistDrilldownProps) {
+  const [wishlists, setWishlists] = useState<WishlistSummary[]>([]);
+  const [selectedWishlist, setSelectedWishlist] = useState<WishlistSummary | null>(null);
+  const [items, setItems] = useState<WishlistItemResponse[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setSelectedWishlist(null);
+    setItems([]);
+    setError(null);
+    setLoading(true);
+    getUserWishlists(viewingUser.id)
+      .then(setWishlists)
+      .catch((err) => setError(err instanceof Error ? err.message : 'Failed to load wishlists'))
+      .finally(() => setLoading(false));
+  }, [viewingUser.id]);
+
+  const fetchItems = useCallback(async (wishlistId: number) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await getWishlistItemsForWishlist(wishlistId);
+      setItems(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load items');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const handleSelectWishlist = async (wl: WishlistSummary) => {
+    setSelectedWishlist(wl);
+    await fetchItems(wl.id);
+  };
+
+  const handleBackToWishlists = () => {
+    setSelectedWishlist(null);
+    setItems([]);
+  };
+
+  const handleClaim = async (itemId: number) => {
+    await onClaim(itemId);
+    if (selectedWishlist) await fetchItems(selectedWishlist.id);
+  };
+
+  const handleUnclaim = async (itemId: number) => {
+    await onUnclaim(itemId);
+    if (selectedWishlist) await fetchItems(selectedWishlist.id);
+  };
+
+  if (selectedWishlist) {
+    return (
+      <>
+        <div className="panel-header">
+          <div>
+            <button className="secondary-action" onClick={handleBackToWishlists} style={{ marginBottom: '0.5rem' }}>
+              ← Back to {viewingUser.name}'s wishlists
+            </button>
+            <h2>{selectedWishlist.title}</h2>
+            <p className="subtle">{viewingUser.name}'s wishlist</p>
+          </div>
+        </div>
+
+        {loading && <p className="subtle">Loading...</p>}
+        {error && <p className="form-error">{error}</p>}
+
+        {!loading && !error && items.length === 0 && (
+          <div className="empty-state">
+            <h3>No items</h3>
+            <p>This wishlist has no items yet.</p>
+          </div>
+        )}
+
+        {items.length > 0 && (
+          <div className="wishlist-stack">
+            {items.map((item) => (
+              <WishlistItemCard
+                key={item.id}
+                {...item}
+                isOwner={false}
+                onDelete={() => undefined}
+                onEdit={async () => undefined}
+                onClaim={handleClaim}
+                onUnclaim={handleUnclaim}
+              />
+            ))}
+          </div>
+        )}
+      </>
+    );
+  }
+
+  return (
+    <>
+      <div className="panel-header">
+        <div>
+          <button className="secondary-action" onClick={onBack} style={{ marginBottom: '0.5rem' }}>
+            ← Back to feed
+          </button>
+          <h2>{viewingUser.name}'s wishlists</h2>
+        </div>
+      </div>
+
+      {loading && <p className="subtle">Loading...</p>}
+      {error && <p className="form-error">{error}</p>}
+
+      {!loading && !error && wishlists.length === 0 && (
+        <div className="empty-state">
+          <h3>No wishlists</h3>
+          <p>{viewingUser.name} hasn't created any wishlists yet.</p>
+        </div>
+      )}
+
+      {wishlists.length > 0 && (
+        <div className="wishlist-list">
+          {wishlists.map((wl) => (
+            <button
+              key={wl.id}
+              className="wishlist-row"
+              onClick={() => void handleSelectWishlist(wl)}
+              style={{ width: '100%', textAlign: 'left', cursor: 'pointer', background: 'none', border: '1px solid #dbeafe' }}
+            >
+              <strong>{wl.title}</strong>
+              <span className="pill">
+                {wl.itemCount} {wl.itemCount === 1 ? 'item' : 'items'}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/components/WishlistItemCard.tsx
+++ b/apps/web/src/components/WishlistItemCard.tsx
@@ -8,15 +8,20 @@ export default function WishlistItemCard({
   wishlistTitle,
   url,
   price,
+  isClaimed,
+  isClaimedByMe,
   isOwner,
   onDelete,
   onEdit,
+  onClaim,
+  onUnclaim,
 }: CardProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [editName, setEditName] = useState(name);
   const [editUrl, setEditUrl] = useState(url ?? '');
   const [editPrice, setEditPrice] = useState(price != null ? String(price) : '');
   const [saving, setSaving] = useState(false);
+  const [claiming, setClaiming] = useState(false);
 
   const handleSave = async () => {
     setSaving(true);
@@ -37,6 +42,18 @@ export default function WishlistItemCard({
     setEditUrl(url ?? '');
     setEditPrice(price != null ? String(price) : '');
     setIsEditing(false);
+  };
+
+  const handleClaim = async () => {
+    if (!onClaim) return;
+    setClaiming(true);
+    try { await onClaim(id); } finally { setClaiming(false); }
+  };
+
+  const handleUnclaim = async () => {
+    if (!onUnclaim) return;
+    setClaiming(true);
+    try { await onUnclaim(id); } finally { setClaiming(false); }
   };
 
   if (isEditing) {
@@ -97,6 +114,7 @@ export default function WishlistItemCard({
         )}
         {price != null && <p className="card-price">${price.toFixed(2)}</p>}
       </div>
+
       {isOwner && (
         <div className="card-actions">
           <button className="secondary-action" onClick={() => setIsEditing(true)}>
@@ -105,6 +123,33 @@ export default function WishlistItemCard({
           <button className="secondary-action" onClick={() => onDelete(id)}>
             Delete
           </button>
+          {isClaimed && <span className="pill">Claimed</span>}
+        </div>
+      )}
+
+      {!isOwner && (
+        <div className="card-actions">
+          {isClaimed && !isClaimedByMe && (
+            <span className="pill">Claimed</span>
+          )}
+          {isClaimedByMe && (
+            <button
+              className="secondary-action"
+              onClick={() => void handleUnclaim()}
+              disabled={claiming}
+            >
+              {claiming ? 'Unclaiming...' : 'Unclaim'}
+            </button>
+          )}
+          {!isClaimed && (
+            <button
+              className="primary-action"
+              onClick={() => void handleClaim()}
+              disabled={claiming}
+            >
+              {claiming ? 'Claiming...' : 'Claim'}
+            </button>
+          )}
         </div>
       )}
     </div>

--- a/apps/web/src/components/index.ts
+++ b/apps/web/src/components/index.ts
@@ -23,3 +23,4 @@ export { default as WishlistItemCard } from './WishlistItemCard';
 export { default as FamiliesPanel } from './FamiliesPanel';
 export { default as FollowUserRow } from './FollowUserRow';
 export { default as UserSearchPanel } from './UserSearchPanel';
+export { default as WishlistDrilldown } from './WishlistDrilldown';

--- a/apps/web/src/types/wishlist.tsx
+++ b/apps/web/src/types/wishlist.tsx
@@ -53,4 +53,6 @@ export interface CardProps extends WishlistItemResponse {
   isOwner: boolean;
   onDelete: (id: number) => void;
   onEdit: (id: number, data: UpdateWishlistItemInput) => Promise<void>;
+  onClaim?: (id: number) => Promise<void>;
+  onUnclaim?: (id: number) => Promise<void>;
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -14,6 +14,8 @@ export type WishlistItemResponse = WishlistItem & {
   wishlistTitle: string;
   ownerId: number;
   ownerName: string;
+  isClaimed: boolean;
+  isClaimedByMe: boolean;
 };
 
 export type PaginationMeta = {


### PR DESCRIPTION
## Summary

- **Gift claiming** — `POST /api/wishlist-items/:id/claim` and `unclaim`; idempotent; owner privacy enforced (claimedByUserId never in API response)
- **Browse wishlists** — `GET /api/users/:userId/wishlists` and `GET /api/wishlists/:wishlistId/items` (requires shared family)
- **Claim UI** — viewers see Claim/Unclaim buttons; owners see only a "Claimed" badge
- **Drill-down navigation** — "View wishlist" on a family member opens a drill-down panel (wishlists → items) replacing the feed content

Closes #48, #49, #50, #51, #52, #53, #46, #47, #33, #34, #35

## Test plan

- [ ] `POST /api/wishlist-items/:id/claim` → 200; same user again → 200 (idempotent); other user → 409; own item → 403
- [ ] `POST /api/wishlist-items/:id/unclaim` → 204 (claimer); 403 (non-claimer); 204 if no claim
- [ ] Inspect `GET /api/wishlist-items` JSON — `claimedByUserId` absent at all levels
- [ ] Feed cards: Claim button on others' items; Claimed badge on own claimed items
- [ ] Click "View wishlist" on family member → drill-down opens → wishlists list → click wishlist → items with Claim buttons
- [ ] Back navigation works at each drill-down level
- [ ] `npm test` in `apps/api` — 38 tests pass
- [ ] `tsc --noEmit` in `apps/api` and `apps/web` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)