### PR TITLE
Frontend quality fixes: bugs, deduplication, parallel fetches

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -227,8 +227,7 @@ function App() {
         setFamilyNotice(`You joined ${family.name}.`);
         clearInviteTokenFromUrl();
         setPendingInviteToken(null);
-        await fetchFamilies();
-        await fetchData();
+        await Promise.all([fetchFamilies(), fetchData()]);
       } catch (err) {
         setFamilyError(err instanceof Error ? err.message : 'Failed to accept family invite');
         clearInviteTokenFromUrl();
@@ -378,11 +377,9 @@ function App() {
     setFamilyNotice(null);
     try {
       const family = await createFamily(familyForm.createName.trim());
-      setFamilies((current) => [...current, family]);
       setFamilyForm({ createName: '' });
       setFamilyNotice(`Created ${family.name}.`);
-      await fetchFamilies();
-      await fetchData();
+      await Promise.all([fetchFamilies(), fetchData()]);
     } catch (err) {
       setFamilyError(err instanceof Error ? err.message : 'Failed to create family');
     }
@@ -435,8 +432,7 @@ function App() {
       try {
         await addFamilyMember(familyId, userId);
         setFamilyNotice('Member added successfully.');
-        await fetchFamilies();
-        await fetchData();
+        await Promise.all([fetchFamilies(), fetchData()]);
       } catch (err) {
         setAddMemberError(err instanceof Error ? err.message : 'Failed to add member');
       } finally {
@@ -553,9 +549,7 @@ function App() {
         resolvedId = newWishlist.id;
       }
       await createWishlistItem(resolvedId, data);
-      await fetchData();
-      await fetchMyWishlists();
-      await fetchMyItems();
+      await Promise.all([fetchData(), fetchMyWishlists(), fetchMyItems()]);
     } catch (err) {
       setAddItemError(err instanceof Error ? err.message : 'Failed to add item');
     } finally {
@@ -722,13 +716,11 @@ function App() {
       .map((member) => ({ member, familyName: family.name })),
   );
 
-  const myItemCount = myItems.length;
-
   return (
     <div className="app-shell">
       <AppHeader userName={currentUser.name} onSignOut={() => void handleLogout()} />
       <StatsRow
-        myItemCount={myItemCount}
+        myItemCount={myItems.length}
         myWishlistCount={myWishlists.length}
         familyCount={families.length}
       />
@@ -866,13 +858,7 @@ function App() {
                           key={item.id}
                           {...item}
                           isOwner={item.ownerId === currentUser.id}
-                          onDelete={(id) => {
-                            if (item.ownerId !== currentUser.id) {
-                              setError('You can only delete items from your own wishlist.');
-                              return;
-                            }
-                            void onDeleteItem(id);
-                          }}
+                          onDelete={(id) => void onDeleteItem(id)}
                           onEdit={handleEditItem}
                           onClaim={item.ownerId !== currentUser.id ? handleClaim : undefined}
                           onUnclaim={item.ownerId !== currentUser.id ? handleUnclaim : undefined}

--- a/apps/web/src/api/wishlistItems.tsx
+++ b/apps/web/src/api/wishlistItems.tsx
@@ -1,49 +1,21 @@
 import type { PaginatedWishlistItems, UpdateWishlistItemInput, WishlistItem } from '@wishlist/shared';
 import { apiRequest } from './auth';
 
-const BASE_URL = 'http://localhost:3000';
-
-export async function getWishlistItems(
-  page: number,
-  limit: number,
-  userId?: number,
-): Promise<PaginatedWishlistItems> {
+export function getWishlistItems(page: number, limit: number, userId?: number): Promise<PaginatedWishlistItems> {
   const params = new URLSearchParams({
     page: String(page),
     limit: String(limit),
   });
 
   if (userId) {
-    params.append(`userId`, String(userId));
+    params.append('userId', String(userId));
   }
 
-  const response = await fetch(`${BASE_URL}/api/wishlist-items?${params.toString()}`, {
-    credentials: 'include',
-  });
-
-  if (!response.ok) {
-    const data = (await response.json().catch(() => null)) as {
-      message?: string;
-      error?: string;
-    } | null;
-    throw new Error(data?.message ?? data?.error ?? 'Failed to fetch wishlist items');
-  }
-  return response.json() as Promise<PaginatedWishlistItems>;
+  return apiRequest<PaginatedWishlistItems>(`/api/wishlist-items?${params.toString()}`);
 }
 
-export async function deleteWishListItem(itemId: number) {
-  const response = await fetch(`${BASE_URL}/api/wishlist-items/${itemId}`, {
-    method: 'DELETE',
-    credentials: 'include',
-  });
-
-  if (!response.ok) {
-    const data = (await response.json().catch(() => null)) as {
-      message?: string;
-      error?: string;
-    } | null;
-    throw new Error(data?.message ?? data?.error ?? `Failed to delete itemId: ${itemId}`);
-  }
+export function deleteWishListItem(itemId: number) {
+  return apiRequest<void>(`/api/wishlist-items/${itemId}`, { method: 'DELETE' });
 }
 
 export function updateWishlistItem(id: number, data: UpdateWishlistItemInput) {

--- a/apps/web/src/components/Button.tsx
+++ b/apps/web/src/components/Button.tsx
@@ -7,7 +7,7 @@ interface ButtonProps {
 const Button = ({ name, handleButton, disabled }: ButtonProps) => {
   return (
     <button
-      type="submit"
+      type="button"
       className="
                 px-4 py-2 mx-2 rounded-md
                 bg-blue-600 text-white

--- a/apps/web/src/components/WishlistItemCard.tsx
+++ b/apps/web/src/components/WishlistItemCard.tsx
@@ -5,6 +5,7 @@ const PRIORITY_LABELS: Record<number, string> = { 1: 'High', 2: 'Medium', 3: 'Lo
 
 export default function WishlistItemCard({
   id,
+  wishlistId,
   name,
   ownerName,
   wishlistTitle,


### PR DESCRIPTION
## Summary

- **Bug fix**: `wishlistId` was missing from `WishlistItemCard` destructuring — the "Move to" dropdown filter was always comparing against `undefined`, so it showed all wishlists including the one the item already belongs to
- **Bug fix**: `Button` had `type="submit"` hardcoded on a generic nav button (used for pagination Back/Next), which could accidentally submit a parent form
- **Deduplication**: `getWishlistItems` and `deleteWishListItem` in `wishlistItems.tsx` were hand-rolling `fetch` with their own hardcoded `BASE_URL` and duplicated error/credential handling — consolidated to use the existing `apiRequest` utility like the other 4 functions in the same file
- **Parallel fetches**: Several handlers (`handleAddItem`, `handleCreateFamily`, `handleAddMember`, invite acceptance) were awaiting independent fetch calls sequentially; changed to `Promise.all`
- **Removed wasted optimistic update** in `handleCreateFamily`: it set `families` state then immediately overwrote it via `fetchFamilies()`
- **Removed dead code**: feed tab `onDelete` re-checked ownership before calling the delete handler, but `WishlistItemCard` only renders the Delete button when `isOwner` is true
- **Removed pointless variable**: `myItemCount` was a one-liner alias for `myItems.length` used exactly once

## Test plan

- [ ] Add an item to a wishlist and confirm the "Move to" dropdown excludes the item's current wishlist
- [ ] Click pagination Back/Next — confirm it does not submit any surrounding form
- [ ] Add an item, create a family, add a member — confirm the UI updates correctly after each action
- [ ] Create a family invite link and accept it — confirm family list refreshes

🤖 Generated with [Claude Code](https://claude.com/claude-code)