### PR TITLE
Address PR #95 review findings: extract mapper, restore expiresAt, add tests

### DIFF
--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -154,6 +154,7 @@ describe('AuthService', () => {
       message:
         'If an account exists for that email, a reset token has been generated.',
       resetToken: expect.any(String),
+      expiresAt: expect.any(String),
     });
   });
 

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -202,7 +202,10 @@ export class AuthService {
     return {
       message:
         'If an account exists for that email, a reset token has been generated.',
-      ...(process.env.NODE_ENV !== 'production' && { resetToken: rawToken }),
+      ...(process.env.NODE_ENV !== 'production' && {
+        resetToken: rawToken,
+        expiresAt: new Date(Date.now() + PASSWORD_RESET_DURATION_MS).toISOString(),
+      }),
     };
   }
 

--- a/apps/api/src/users/users.controller.spec.ts
+++ b/apps/api/src/users/users.controller.spec.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/unbound-method */
+import { ForbiddenException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import type { AuthenticatedUser } from '../auth/auth.types';
 import { AuthGuard } from '../auth/auth.guard';
@@ -72,6 +73,16 @@ describe('UsersController', () => {
 
       expect(wishlistsServiceMock.listUserWishlists).toHaveBeenCalledWith(1, 2);
       expect(result).toEqual(wishlists);
+    });
+
+    it('propagates ForbiddenException when target user is not in same family', async () => {
+      (wishlistsServiceMock.listUserWishlists as jest.Mock).mockRejectedValue(
+        new ForbiddenException(),
+      );
+
+      await expect(controller.listUserWishlists(99, currentUser)).rejects.toThrow(
+        ForbiddenException,
+      );
     });
   });
 });

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -13,6 +13,7 @@ export class UsersService {
       where: {
         id: { not: currentUserId },
         // SQLite is case-insensitive by default; add mode: 'insensitive' when migrating to Postgres
+        // See: https://github.com/lizthrilla/wishlist/issues/96
         OR: [{ name: { contains: trimmed } }, { email: { contains: trimmed } }],
       },
       select: { id: true, name: true, email: true },

--- a/apps/api/src/wishlist-items/dto/wishlist-item-response.ts
+++ b/apps/api/src/wishlist-items/dto/wishlist-item-response.ts
@@ -1,0 +1,50 @@
+export const ITEM_FIELDS_SELECT = {
+  id: true,
+  name: true,
+  url: true,
+  price: true,
+  note: true,
+  priority: true,
+  quantity: true,
+  imageUrl: true,
+  category: true,
+  store: true,
+  variant: true,
+  createdAt: true,
+  updatedAt: true,
+  wishlistId: true,
+} as const;
+
+export const WISHLIST_OWNER_SELECT = {
+  title: true,
+  userId: true,
+  user: { select: { name: true } },
+} as const;
+
+type ItemWithOwner = {
+  id: number;
+  name: string;
+  url: string | null;
+  price: number | null;
+  note: string | null;
+  priority: number;
+  quantity: number;
+  imageUrl: string | null;
+  category: string | null;
+  store: string | null;
+  variant: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  wishlistId: number;
+  wishlist: { title: string; userId: number; user: { name: string } };
+};
+
+export function toWishlistItemResponse(item: ItemWithOwner) {
+  const { wishlist, ...fields } = item;
+  return {
+    ...fields,
+    wishlistTitle: wishlist.title,
+    ownerId: wishlist.userId,
+    ownerName: wishlist.user.name,
+  };
+}

--- a/apps/api/src/wishlist-items/wishlist-items.controller.spec.ts
+++ b/apps/api/src/wishlist-items/wishlist-items.controller.spec.ts
@@ -62,4 +62,43 @@ describe('WishlistItemsController', () => {
 
     expect(serviceMock.getWishlistItems).toHaveBeenCalledWith(7, 1, 10, 9);
   });
+
+  describe('pagination clamping', () => {
+    beforeEach(() => {
+      serviceMock.getWishlistItems = jest.fn().mockResolvedValue({
+        data: [],
+        meta: { page: 1, limit: 10, total: 0, totalPages: 0 },
+      });
+    });
+
+    it('clamps negative page to 1', async () => {
+      await controller.getWishlistItems(
+        { id: 7, name: 'Alice', email: 'alice@example.com' },
+        -5,
+        10,
+        undefined,
+      );
+      expect(serviceMock.getWishlistItems).toHaveBeenCalledWith(7, 1, 10, undefined);
+    });
+
+    it('clamps zero limit to 1', async () => {
+      await controller.getWishlistItems(
+        { id: 7, name: 'Alice', email: 'alice@example.com' },
+        1,
+        0,
+        undefined,
+      );
+      expect(serviceMock.getWishlistItems).toHaveBeenCalledWith(7, 1, 1, undefined);
+    });
+
+    it('clamps overlarge limit to 100', async () => {
+      await controller.getWishlistItems(
+        { id: 7, name: 'Alice', email: 'alice@example.com' },
+        1,
+        999,
+        undefined,
+      );
+      expect(serviceMock.getWishlistItems).toHaveBeenCalledWith(7, 1, 100, undefined);
+    });
+  });
 });

--- a/apps/api/src/wishlist-items/wishlist-items.service.ts
+++ b/apps/api/src/wishlist-items/wishlist-items.service.ts
@@ -9,23 +9,11 @@ import { FamiliesService } from '../families/families.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { UpdateWishlistItemDto } from './dto/update-wishlist-item.dto';
 import { MoveWishlistItemDto } from './dto/move-wishlist-item.dto';
-
-const ITEM_FIELDS_SELECT = {
-  id: true,
-  name: true,
-  url: true,
-  price: true,
-  note: true,
-  priority: true,
-  quantity: true,
-  imageUrl: true,
-  category: true,
-  store: true,
-  variant: true,
-  createdAt: true,
-  updatedAt: true,
-  wishlistId: true,
-} as const;
+import {
+  ITEM_FIELDS_SELECT,
+  WISHLIST_OWNER_SELECT,
+  toWishlistItemResponse,
+} from './dto/wishlist-item-response';
 
 @Injectable()
 export class WishlistItemsService {
@@ -83,41 +71,16 @@ export class WishlistItemsService {
           ...ITEM_FIELDS_SELECT,
           claim: { select: { claimedByUserId: true } },
           wishlist: {
-            select: {
-              id: true,
-              title: true,
-              userId: true,
-              user: {
-                select: {
-                  id: true,
-                  name: true,
-                },
-              },
-            },
+            select: WISHLIST_OWNER_SELECT,
           },
         },
       }),
       this.prisma.wishlistItem.count({ where }),
     ]);
-    const flatData = data.map((item) => ({
-      id: item.id,
-      name: item.name,
-      url: item.url,
-      price: item.price,
-      note: item.note,
-      priority: item.priority,
-      quantity: item.quantity,
-      imageUrl: item.imageUrl,
-      category: item.category,
-      store: item.store,
-      variant: item.variant,
-      createdAt: item.createdAt,
-      wishlistId: item.wishlistId,
-      wishlistTitle: item.wishlist.title,
-      ownerId: item.wishlist.user.id,
-      ownerName: item.wishlist.user.name,
-      isClaimed: item.claim !== null,
-      isClaimedByMe: item.claim?.claimedByUserId === currentUserId,
+    const flatData = data.map(({ claim, ...item }) => ({
+      ...toWishlistItemResponse(item),
+      isClaimed: claim !== null,
+      isClaimedByMe: claim?.claimedByUserId === currentUserId,
     }));
     const totalPages = Math.ceil(total / limit);
     return {
@@ -168,34 +131,12 @@ export class WishlistItemsService {
       select: {
         ...ITEM_FIELDS_SELECT,
         wishlist: {
-          select: {
-            title: true,
-            userId: true,
-            user: { select: { name: true } },
-          },
+          select: WISHLIST_OWNER_SELECT,
         },
       },
     });
 
-    return {
-      id: updated.id,
-      name: updated.name,
-      url: updated.url,
-      price: updated.price,
-      note: updated.note,
-      priority: updated.priority,
-      quantity: updated.quantity,
-      imageUrl: updated.imageUrl,
-      category: updated.category,
-      store: updated.store,
-      variant: updated.variant,
-      createdAt: updated.createdAt,
-      updatedAt: updated.updatedAt,
-      wishlistId: updated.wishlistId,
-      wishlistTitle: updated.wishlist.title,
-      ownerId: updated.wishlist.userId,
-      ownerName: updated.wishlist.user.name,
-    };
+    return toWishlistItemResponse(updated);
   }
 
   async moveWishlistItem(

--- a/apps/api/src/wishlists/wishlists.service.ts
+++ b/apps/api/src/wishlists/wishlists.service.ts
@@ -6,6 +6,11 @@ import {
 import { PrismaService } from '../prisma/prisma.service';
 import { FamiliesService } from '../families/families.service';
 import { CreateWishlistItemDto } from '../wishlist-items/dto/create-wishlist-item.dto';
+import {
+  ITEM_FIELDS_SELECT,
+  WISHLIST_OWNER_SELECT,
+  toWishlistItemResponse,
+} from '../wishlist-items/dto/wishlist-item-response';
 import { CreateWishlistDto } from './dto/create-wishlist.dto';
 import { UpdateWishlistDto } from './dto/update-wishlist.dto';
 
@@ -18,23 +23,6 @@ const WISHLIST_SUMMARY_SELECT = {
   createdAt: true,
   updatedAt: true,
   _count: { select: { items: true } },
-} as const;
-
-const ITEM_FIELDS_SELECT = {
-  id: true,
-  name: true,
-  url: true,
-  price: true,
-  note: true,
-  priority: true,
-  quantity: true,
-  imageUrl: true,
-  category: true,
-  store: true,
-  variant: true,
-  createdAt: true,
-  updatedAt: true,
-  wishlistId: true,
 } as const;
 
 @Injectable()
@@ -214,34 +202,12 @@ export class WishlistsService {
       select: {
         ...ITEM_FIELDS_SELECT,
         wishlist: {
-          select: {
-            title: true,
-            userId: true,
-            user: { select: { name: true } },
-          },
+          select: WISHLIST_OWNER_SELECT,
         },
       },
     });
 
-    return {
-      id: created.id,
-      name: created.name,
-      url: created.url,
-      price: created.price,
-      note: created.note,
-      priority: created.priority,
-      quantity: created.quantity,
-      imageUrl: created.imageUrl,
-      category: created.category,
-      store: created.store,
-      variant: created.variant,
-      createdAt: created.createdAt,
-      updatedAt: created.updatedAt,
-      wishlistId: created.wishlistId,
-      wishlistTitle: created.wishlist.title,
-      ownerId: created.wishlist.userId,
-      ownerName: created.wishlist.user.name,
-    };
+    return toWishlistItemResponse(created);
   }
 
   async deleteWishlist(


### PR DESCRIPTION
## Summary

Addresses all findings from the code review of PR #95 (backend quality check).

## Changes

### Extract shared `toWishlistItemResponse` mapper (Important)

Created `apps/api/src/wishlist-items/dto/wishlist-item-response.ts` exporting:
- `ITEM_FIELDS_SELECT` — shared Prisma select constant (was duplicated in both services)
- `WISHLIST_OWNER_SELECT` — shared nested wishlist+user select
- `toWishlistItemResponse()` — mapper function that flattens item + owner fields

Updated `wishlists.service.ts` and `wishlist-items.service.ts` to use the shared exports, removing 5 duplicated flat-map sites. Also fixes a silent `ownerId` inconsistency (`wishlist.user.id` → `wishlist.userId`).

### Restore `expiresAt` to `forgotPassword` dev response (Important)

Added `expiresAt: new Date(Date.now() + PASSWORD_RESET_DURATION_MS).toISOString()` to the non-production spread in `auth.service.ts`. The dev panel in `App.tsx:670` now displays the token expiry again. No extra DB read required — uses the existing constant. Extended the existing test to assert `expiresAt` is present.

### Add `ForbiddenException` propagation test (Minor)

Added a second test to `users.controller.spec.ts` confirming `ForbiddenException` from the service propagates through `listUserWishlists`.

### Add pagination clamping tests (Minor)

Added 3 tests to `wishlist-items.controller.spec.ts` pinning the existing clamping behavior: `page=-5→1`, `limit=0→1`, `limit=999→100`.

### Link GitHub issue to SQLite comment (Minor)

Created issue #96 and linked it in the `mode: 'insensitive'` TODO comment in `users.service.ts`.

## Test Results

97 tests pass (was 93 before this PR — 4 new tests added).